### PR TITLE
feat: v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Added
 - 新增 `use_builtin_provider` 配置项：支持使用 AstrBot 自带供应商
 - 新增 `provider` 配置项：选择已配置的 LLM 供应商（仅当启用自带供应商时生效）
-- 新增 `max_retries` 配置项：最大重试次数（默认: 3）
+- 新增 `max_retries` 配置项：最大重试次数（默认: 3，支持滑块调节 0-10）
 - 新增 `retry_delay` 配置项：重试间隔时间（默认: 1 秒，支持滑块调节 0.1-5 秒）
 - 新增 `retryable_status_codes` 配置项：可重试的 HTTP 状态码列表（默认: 429, 500, 502, 503, 504）
 - 新增 `custom_system_prompt` 配置项：自定义系统提示词（支持多行编辑器）
@@ -17,9 +17,15 @@
 
 ### Changed
 - 当启用自带供应商时，自动使用供应商默认模型和参数（不覆盖 model/reasoning 等字段）
-- 重试功能仅对 `/grok` 指令和 LLM Tool 启用，Skill 脚本自行决定是否重试
+- 重试功能仅对 `/grok` 指令启用，LLM Tool 不再自动重试（由 AI 自行决定是否重新调用）
 - `retryable_status_codes` 仅对自定义 HTTP 客户端生效，内置供应商使用异常重试机制
-- 配置项按功能分组排序：供应商设置、连接设置、行为设置、输出设置、Skill 设置、HTTP 扩展
+- 内置供应商重试延迟改为线性退避策略（`retry_delay * attempts`），与外部客户端行为一致
+- 配置项描述和提示信息拆分为 `description` + `hint`，提升可读性
+- 简化 `max_retries` / `retry_delay` 配置解析逻辑，由 UI 滑块约束输入范围
+
+### Fixed
+- 修复 `/grok` 指令发送失败后 LLM 兜底重复调用 `grok_web_search` 的问题
+- 修复自定义供应商模式下 `/grok help` 仍显示内置供应商名称的问题
 
 <details>
 <summary>历史版本</summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 本项目遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)。
 
+## [1.0.5] - 2026-02-12
+
+### Added
+- 新增 `use_builtin_provider` 配置项：支持使用 AstrBot 自带供应商
+- 新增 `provider` 配置项：选择已配置的 LLM 供应商（仅当启用自带供应商时生效）
+- 新增 `max_retries` 配置项：最大重试次数（默认: 3）
+- 新增 `retry_delay` 配置项：重试间隔时间（默认: 1 秒，支持滑块调节 0.1-5 秒）
+- 新增 `retryable_status_codes` 配置项：可重试的 HTTP 状态码列表（默认: 429, 500, 502, 503, 504）
+- 新增 `custom_system_prompt` 配置项：自定义系统提示词（支持多行编辑器）
+- `/grok` 指令使用独立的中文系统提示词，要求使用中文回复
+- `/grok help` 显示当前配置状态（供应商来源、模型、提示词类型）
+- 支持延迟初始化：启用自带供应商时，在 AstrBot 加载完成后初始化
+
+### Changed
+- 当启用自带供应商时，自动使用供应商默认模型和参数（不覆盖 model/reasoning 等字段）
+- 重试功能仅对 `/grok` 指令和 LLM Tool 启用，Skill 脚本自行决定是否重试
+- `retryable_status_codes` 仅对自定义 HTTP 客户端生效，内置供应商使用异常重试机制
+- 配置项按功能分组排序：供应商设置、连接设置、行为设置、输出设置、Skill 设置、HTTP 扩展
+
+<details>
+<summary>历史版本</summary>
+
 ## [1.0.4] - 2026-02-03
 
 ### Added
@@ -12,9 +34,6 @@
 ### Changed
 - 默认模型从 `grok-4-expert` 改为 `grok-4-fast`
 - 开启思考模式时自动添加 `reasoning_effort: "high"` 和 `reasoning_budget_tokens` 参数
-
-<details>
-<summary>历史版本</summary>
 
 ## [1.0.3] - 2026-02-02
 

--- a/README.md
+++ b/README.md
@@ -23,20 +23,53 @@
 
 ## 配置
 
+### 供应商设置
+
 | 配置项 | 类型 | 必填 | 说明 |
 |--------|------|------|------|
-| `base_url` | string | 是 | Grok API 端点 URL |
-| `api_key` | string | 是 | API 密钥 |
-| `model` | string | 否 | 模型名称（默认: grok-4-fast） |
+| `use_builtin_provider` | bool | 否 | 是否使用 AstrBot 自带供应商（默认: false） |
+| `provider` | string | 条件 | 选择已配置的 LLM 供应商（启用自带供应商时必填） |
+| `model` | string | 否 | 模型名称（默认: grok-4-fast，启用自带供应商时使用供应商默认模型） |
+
+### 连接设置
+
+| 配置项 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| `base_url` | string | 条件 | Grok API 端点 URL（使用自定义供应商时必填） |
+| `api_key` | string | 条件 | API 密钥（使用自定义供应商时必填） |
+| `timeout_seconds` | int | 否 | 超时时间（默认: 60 秒） |
+| `reuse_session` | bool | 否 | 是否复用 HTTP 会话（高频调用场景可开启，默认: false） |
+
+### 行为设置
+
+| 配置项 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
 | `enable_thinking` | bool | 否 | 是否开启思考模式（默认: true） |
 | `thinking_budget` | int | 否 | 思考 token 预算（默认: 32000） |
-| `timeout_seconds` | int | 否 | 超时时间（默认: 60秒） |
+| `max_retries` | int | 否 | 最大重试次数（默认: 3） |
+| `retry_delay` | float | 否 | 重试间隔时间（默认: 1 秒，范围 0.1-5 秒） |
+| `retryable_status_codes` | list | 否 | 可重试的 HTTP 状态码（默认: [429, 500, 502, 503, 504]） |
+
+### 输出设置
+
+| 配置项 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
 | `show_sources` | bool | 否 | 是否显示来源 URL（默认: false） |
 | `max_sources` | int | 否 | 最大返回来源数量，0 表示不限制（默认: 5） |
+| `custom_system_prompt` | text | 否 | 自定义系统提示词（留空使用默认提示词） |
+
+### Skill 设置
+
+| 配置项 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| `enable_skill` | bool | 否 | 是否安装 Skill 到 skills 目录（启用后将禁用 LLM Tool） |
+
+### HTTP 扩展
+
+| 配置项 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
 | `extra_body` | JSON | 否 | 额外请求体参数 |
 | `extra_headers` | JSON | 否 | 额外请求头 |
-| `enable_skill` | bool | 否 | 是否安装 Skill 到 skills 目录（启用后将禁用 LLM Tool） |
-| `reuse_session` | bool | 否 | 是否复用 HTTP 会话（高频调用场景可开启，默认: false） |
 
 ## 使用
 
@@ -45,8 +78,16 @@
 ```
 /grok Python 3.12 有什么新特性
 /grok 最新的 AI 新闻
-/grok help
+/grok help              # 显示帮助和当前配置状态
 ```
+
+> `/grok help` 会显示当前供应商来源、模型、系统提示词类型等配置信息。
+
+### 重试机制
+
+- `/grok` 指令和 LLM Tool 启用自动重试功能
+- 重试仅对自定义 HTTP 客户端生效（通过 `retryable_status_codes` 配置）
+- 使用 AstrBot 自带供应商时，采用异常重试机制（不受 `retryable_status_codes` 限制）
 
 ### LLM Tool
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@
 
 ### 重试机制
 
-- `/grok` 指令和 LLM Tool 启用自动重试功能
-- 重试仅对自定义 HTTP 客户端生效（通过 `retryable_status_codes` 配置）
+- `/grok` 指令启用自动重试功能，使用线性退避策略（`retry_delay * 重试次数`）
+- LLM Tool 不自动重试，失败立即返回，由 AI 自行决定是否重新调用
+- 重试仅对自定义 HTTP 客户端通过 `retryable_status_codes` 匹配状态码
 - 使用 AstrBot 自带供应商时，采用异常重试机制（不受 `retryable_status_codes` 限制）
 
 ### LLM Tool

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -57,7 +57,8 @@
     "type": "int",
     "description": "最大重试次数",
     "hint": "请求失败时的最大重试次数",
-    "default": 3
+    "default": 3,
+    "slider": {"min": 0, "max": 10, "step": 1}
   },
   "retry_delay": {
     "type": "float",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,56 +1,62 @@
 {
   "use_builtin_provider": {
     "type": "bool",
-    "description": "是否使用 AstrBot 自带供应商（启用后将使用已配置的 LLM 供应商）",
-    "hint": "启用后无需配置模型参数",
+    "description": "是否使用 AstrBot 自带供应商",
+    "hint": "启用后将使用已配置的 LLM 供应商,无需配置模型参数",
     "default": false
   },
   "provider": {
     "_special": "select_provider",
     "type": "string",
-    "description": "选择要使用的 LLM 供应商（仅当启用自带供应商时生效）",
-    "hint": "选择一个已配置的 LLM 供应商"
+    "description": "选择要使用的 LLM 供应商",
+    "hint": "仅当启用自带供应商时生效,选择已配置的 LLM 供应商"
   },
   "model": {
     "type": "string",
     "description": "模型名称",
+    "hint": "选择要使用的 Grok 模型",
     "default": "grok-4-fast"
   },
 
   "base_url": {
     "type": "string",
-    "description": "Grok API 端点 URL（使用自定义供应商时必填）",
-    "hint": "例如: https://api.x.ai"
+    "description": "Grok API 端点 URL",
+    "hint": "使用自定义供应商时必填,例如: https://api.example.com"
   },
   "api_key": {
     "type": "string",
-    "description": "Grok API 密钥（使用自定义供应商时必填）",
-    "hint": "你的 API Key"
+    "description": "Grok API 密钥",
+    "hint": "使用自定义供应商时必填,你的 API Key"
   },
   "timeout_seconds": {
     "type": "int",
     "description": "请求超时时间（秒）",
+    "hint": "控制每次请求的最大等待时间",
     "default": 60
   },
   "reuse_session": {
     "type": "bool",
-    "description": "是否复用 HTTP 会话（高频调用场景可开启以减少连接开销）",
+    "description": "是否复用 HTTP 会话",
+    "hint": "高频调用场景可开启以减少连接开销",
     "default": false
   },
 
   "enable_thinking": {
     "type": "bool",
-    "description": "是否开启思考模式（reasoning）",
+    "description": "是否开启思考模式",
+    "hint": "允许模型在回答前进行多轮思考",
     "default": true
   },
   "thinking_budget": {
     "type": "int",
-    "description": "思考 token 预算（仅在开启思考模式时生效）",
+    "description": "思考 token 预算",
+    "hint": "控制思考阶段可使用的最大 token 数量",
     "default": 32000
   },
   "max_retries": {
     "type": "int",
-    "description": "最大重试次数（请求失败时自动重试）",
+    "description": "最大重试次数",
+    "hint": "请求失败时的最大重试次数",
     "default": 3
   },
   "retry_delay": {
@@ -70,16 +76,18 @@
   "show_sources": {
     "type": "bool",
     "description": "是否在结果中显示来源 URL",
+    "hint": "启用后将在搜索结果中显示来源链接",
     "default": false
   },
   "max_sources": {
     "type": "int",
-    "description": "最大返回来源数量（0 表示不限制）",
+    "description": "最大返回来源数量",
+    "hint": "控制返回的来源链接数量.0 表示不限制",
     "default": 5
   },
   "custom_system_prompt": {
     "type": "text",
-    "description": "自定义系统提示词（留空使用默认提示词，支持多行）",
+    "description": "自定义系统提示词",
     "hint": "留空使用默认提示词",
     "default": "",
     "editor_mode": true,
@@ -89,7 +97,8 @@
 
   "enable_skill": {
     "type": "bool",
-    "description": "是否安装 Skill 到 skills 目录（启用后将禁用 LLM Tool）",
+    "description": "是否安装 Skill 到 skills 目录",
+    "hint": "启用后将安装 Skill 以供 AstrBot 使用",
     "default": false
   },
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,19 +1,43 @@
 {
-  "base_url": {
-    "type": "string",
-    "description": "Grok API 端点 URL（必填）",
-    "hint": "例如: https://api.x.ai"
+  "use_builtin_provider": {
+    "type": "bool",
+    "description": "是否使用 AstrBot 自带供应商（启用后将使用已配置的 LLM 供应商）",
+    "hint": "启用后无需配置模型参数",
+    "default": false
   },
-  "api_key": {
+  "provider": {
+    "_special": "select_provider",
     "type": "string",
-    "description": "Grok API 密钥（必填）",
-    "hint": "你的 API Key"
+    "description": "选择要使用的 LLM 供应商（仅当启用自带供应商时生效）",
+    "hint": "选择一个已配置的 LLM 供应商"
   },
   "model": {
     "type": "string",
     "description": "模型名称",
     "default": "grok-4-fast"
   },
+
+  "base_url": {
+    "type": "string",
+    "description": "Grok API 端点 URL（使用自定义供应商时必填）",
+    "hint": "例如: https://api.x.ai"
+  },
+  "api_key": {
+    "type": "string",
+    "description": "Grok API 密钥（使用自定义供应商时必填）",
+    "hint": "你的 API Key"
+  },
+  "timeout_seconds": {
+    "type": "int",
+    "description": "请求超时时间（秒）",
+    "default": 60
+  },
+  "reuse_session": {
+    "type": "bool",
+    "description": "是否复用 HTTP 会话（高频调用场景可开启以减少连接开销）",
+    "default": false
+  },
+
   "enable_thinking": {
     "type": "bool",
     "description": "是否开启思考模式（reasoning）",
@@ -24,11 +48,25 @@
     "description": "思考 token 预算（仅在开启思考模式时生效）",
     "default": 32000
   },
-  "timeout_seconds": {
+  "max_retries": {
     "type": "int",
-    "description": "请求超时时间（秒）",
-    "default": 60
+    "description": "最大重试次数（请求失败时自动重试）",
+    "default": 3
   },
+  "retry_delay": {
+    "type": "float",
+    "description": "重试间隔时间（秒）",
+    "hint": "控制重试间隔，范围 0.1-5 秒",
+    "default": 1.0,
+    "slider": {"min": 0.1, "max": 5, "step": 0.1}
+  },
+  "retryable_status_codes": {
+    "type": "list",
+    "description": "可重试的 HTTP 状态码",
+    "hint": "自定义重试的 HTTP 状态码列表",
+    "default": [429, 500, 502, 503, 504]
+  },
+
   "show_sources": {
     "type": "bool",
     "description": "是否在结果中显示来源 URL",
@@ -39,6 +77,22 @@
     "description": "最大返回来源数量（0 表示不限制）",
     "default": 5
   },
+  "custom_system_prompt": {
+    "type": "text",
+    "description": "自定义系统提示词（留空使用默认提示词，支持多行）",
+    "hint": "留空使用默认提示词",
+    "default": "",
+    "editor_mode": true,
+    "editor_language": "markdown",
+    "editor_theme": "vs-dark"
+  },
+
+  "enable_skill": {
+    "type": "bool",
+    "description": "是否安装 Skill 到 skills 目录（启用后将禁用 LLM Tool）",
+    "default": false
+  },
+
   "extra_body": {
     "type": "text",
     "description": "额外请求体参数（JSON 格式）",
@@ -50,15 +104,6 @@
     "description": "额外请求头（JSON 格式）",
     "hint": "例如: {\"X-Custom-Header\": \"value\"}",
     "default": "{}"
-  },
-  "enable_skill": {
-    "type": "bool",
-    "description": "是否安装 Skill 到 skills 目录（启用后将禁用 LLM Tool）",
-    "default": false
-  },
-  "reuse_session": {
-    "type": "bool",
-    "description": "是否复用 HTTP 会话（高频调用场景可开启以减少连接开销）",
-    "default": false
   }
 }
+

--- a/grok_client.py
+++ b/grok_client.py
@@ -4,6 +4,7 @@ Grok API 异步客户端
 通过 OpenAI 兼容接口调用 Grok 进行联网搜索
 """
 
+import asyncio
 import json
 import re
 import time
@@ -101,6 +102,10 @@ async def grok_search(
     extra_body: dict | None = None,
     extra_headers: dict | None = None,
     session: aiohttp.ClientSession | None = None,
+    system_prompt: str | None = None,
+    max_retries: int = 3,
+    retry_delay: float = 1.0,
+    retryable_status_codes: set[int] | None = None,
 ) -> dict[str, Any]:
     """
     调用 Grok API 进行联网搜索（异步）
@@ -116,6 +121,10 @@ async def grok_search(
         extra_body: 额外请求体参数
         extra_headers: 额外请求头
         session: 可选的 aiohttp.ClientSession，传入时复用，否则创建临时 session
+        system_prompt: 自定义系统提示词，为 None 时使用默认提示词
+        max_retries: 最大重试次数（默认 3 次）
+        retry_delay: 重试间隔时间（秒，默认 1.0）
+        retryable_status_codes: 可重试的 HTTP 状态码集合，为 None 时使用默认值
 
     Returns:
         {
@@ -125,6 +134,7 @@ async def grok_search(
             "raw": str,          # 原始响应（解析失败时）
             "error": str,        # 错误信息（失败时）
             "elapsed_ms": int,   # 耗时
+            "retries": int,      # 重试次数
         }
     """
     started = time.time()
@@ -155,7 +165,8 @@ async def grok_search(
 
     url = f"{normalize_base_url(base_url)}/v1/chat/completions"
 
-    system_prompt = (
+    # 默认系统提示词（LLM Tool 和 Skill 使用）
+    default_system_prompt = (
         "You are a web research assistant. Use live web search/browsing when answering. "
         "Return ONLY a single JSON object with keys: "
         "content (string), sources (array of objects with url/title/snippet when possible). "
@@ -163,15 +174,22 @@ async def grok_search(
         "IMPORTANT: Do NOT use Markdown formatting in the content field - use plain text only."
     )
 
+    # 使用自定义提示词或默认提示词
+    final_system_prompt = (
+        system_prompt if system_prompt is not None else default_system_prompt
+    )
+
+    # 构建请求体：仅当提供 model 时才添加 model 字段（允许供应商/端点使用默认模型）
     body: dict[str, Any] = {
-        "model": model,
         "messages": [
-            {"role": "system", "content": system_prompt},
+            {"role": "system", "content": final_system_prompt},
             {"role": "user", "content": query},
         ],
         "temperature": 0.2,
         "stream": False,
     }
+    if model:
+        body["model"] = model
 
     # 添加思考模式参数
     if enable_thinking:
@@ -315,35 +333,91 @@ async def grok_search(
                     "elapsed_ms": int((time.time() - started) * 1000),
                 }
 
-    try:
-        if session is not None:
-            result = await _do_request(session)
-        else:
-            async with aiohttp.ClientSession() as temp_session:
-                result = await _do_request(temp_session)
+    # 可重试的错误状态码（默认值）
+    if retryable_status_codes is None:
+        retryable_status_codes = {429, 500, 502, 503, 504}
 
-        if not result.get("ok") or "data" not in result:
-            return result
-        data = result["data"]
+    result = None
+    last_error = None
+    retry_count = 0
 
-    except aiohttp.ClientError as e:
+    for attempt in range(max_retries + 1):
+        try:
+            if session is not None:
+                result = await _do_request(session)
+            else:
+                async with aiohttp.ClientSession() as temp_session:
+                    result = await _do_request(temp_session)
+
+            # 检查是否需要重试
+            if result.get("ok") or "data" in result:
+                # 成功或解析成功的响应，跳出循环
+                break
+
+            # 检查是否为可重试的错误
+            error_msg = result.get("error", "")
+            should_retry = False
+
+            # HTTP 状态码可重试
+            if any(f"HTTP {code}" in error_msg for code in retryable_status_codes):
+                should_retry = True
+
+            if should_retry and attempt < max_retries:
+                retry_count = attempt + 1
+                await asyncio.sleep(retry_delay * (attempt + 1))  # 指数退避
+                continue
+
+            # 不可重试的错误，直接返回
+            break
+
+        except aiohttp.ClientError as e:
+            last_error = f"网络请求失败: {e}"
+            if attempt < max_retries:
+                retry_count = attempt + 1
+                await asyncio.sleep(retry_delay * (attempt + 1))
+                continue
+            return {
+                "ok": False,
+                "error": last_error,
+                "content": "",
+                "sources": [],
+                "raw": "",
+                "elapsed_ms": int((time.time() - started) * 1000),
+                "retries": retry_count,
+            }
+        except TimeoutError:
+            last_error = (
+                f"请求超时（{timeout}秒），请检查网络或增加 timeout_seconds 配置"
+            )
+            if attempt < max_retries:
+                retry_count = attempt + 1
+                await asyncio.sleep(retry_delay * (attempt + 1))
+                continue
+            return {
+                "ok": False,
+                "error": last_error,
+                "content": "",
+                "sources": [],
+                "raw": "",
+                "elapsed_ms": int((time.time() - started) * 1000),
+                "retries": retry_count,
+            }
+
+    if result is None:
         return {
             "ok": False,
-            "error": f"网络请求失败: {e}",
+            "error": last_error or "未知错误",
             "content": "",
             "sources": [],
             "raw": "",
             "elapsed_ms": int((time.time() - started) * 1000),
+            "retries": retry_count,
         }
-    except TimeoutError:
-        return {
-            "ok": False,
-            "error": f"请求超时（{timeout}秒），请检查网络或增加 timeout_seconds 配置",
-            "content": "",
-            "sources": [],
-            "raw": "",
-            "elapsed_ms": int((time.time() - started) * 1000),
-        }
+
+    if not result.get("ok") or "data" not in result:
+        result["retries"] = retry_count
+        return result
+    data = result["data"]
 
     # 解析响应
     message = ""
@@ -425,4 +499,5 @@ async def grok_search(
         "model": data.get("model") or model,
         "usage": data.get("usage") or {},
         "elapsed_ms": int((time.time() - started) * 1000),
+        "retries": retry_count,
     }

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from astrbot.core.provider.entities import ProviderRequest
 from astrbot.core.provider.func_tool_manager import FunctionToolManager
 
 from .grok_client import (
+    DEFAULT_JSON_SYSTEM_PROMPT,
     grok_search,
     normalize_api_key,
     normalize_base_url,
@@ -28,15 +29,6 @@ from .grok_client import (
 )
 
 PLUGIN_NAME = "astrbot_plugin_grok_web_search"
-
-# 默认系统提示词（要求返回 JSON 格式）
-DEFAULT_JSON_SYSTEM_PROMPT = (
-    "You are a web research assistant. Use live web search/browsing when answering. "
-    "Return ONLY a single JSON object with keys: "
-    "content (string), sources (array of objects with url/title/snippet when possible). "
-    "Keep content concise and evidence-backed. "
-    "IMPORTANT: Do NOT use Markdown formatting in the content field - use plain text only."
-)
 
 
 class GrokSearchPlugin(Star):
@@ -231,7 +223,6 @@ class GrokSearchPlugin(Star):
         query: str,
         system_prompt: str | None = None,
         use_retry: bool = False,
-        umo: str | None = None,
     ) -> dict:
         """执行搜索
 
@@ -529,7 +520,6 @@ class GrokSearchPlugin(Star):
             query,
             system_prompt=cmd_system_prompt,
             use_retry=True,
-            umo=event.unified_msg_origin,
         )
         yield event.plain_result(self._format_result(result))
 
@@ -543,7 +533,7 @@ class GrokSearchPlugin(Star):
             query(string): 搜索查询内容，应该是清晰具体的问题或关键词
         """
         result = await self._do_search(
-            query, use_retry=True, umo=event.unified_msg_origin
+            query, use_retry=True
         )
         return self._format_result_for_llm(result)
 

--- a/main.py
+++ b/main.py
@@ -457,7 +457,11 @@ class GrokSearchPlugin(Star):
         """返回帮助文本"""
         use_builtin = self.config.get("use_builtin_provider", False)
         mode = "AstrBot 自带" if use_builtin else "自定义"
-        provider_id = self.config.get("provider", "") or "未配置"
+        provider_id = (
+            (self.config.get("provider", "") or "未配置")
+            if use_builtin
+            else (self.config.get("base_url", "") or "未配置")
+        )
         model = (
             "由供应商决定"
             if use_builtin
@@ -524,6 +528,7 @@ class GrokSearchPlugin(Star):
             system_prompt=cmd_system_prompt,
             use_retry=True,
         )
+        event.should_call_llm(True)
         yield event.plain_result(self._format_result(result))
 
     @filter.llm_tool(name="grok_web_search")
@@ -535,7 +540,7 @@ class GrokSearchPlugin(Star):
         Args:
             query(string): 搜索查询内容，应该是清晰具体的问题或关键词
         """
-        result = await self._do_search(query, use_retry=True)
+        result = await self._do_search(query, use_retry=False)
         return self._format_result_for_llm(result)
 
     @filter.on_llm_request()

--- a/main.py
+++ b/main.py
@@ -272,23 +272,8 @@ class GrokSearchPlugin(Star):
         retry_delay = 1.0
         retryable_status_codes = None
         if use_retry:
-            try:
-                max_retries_val = self.config.get("max_retries", 3)
-                max_retries = int(max_retries_val) if max_retries_val is not None else 3
-                if max_retries < 0:
-                    max_retries = 3
-            except (ValueError, TypeError):
-                max_retries = 3
-
-            try:
-                retry_delay_val = self.config.get("retry_delay", 1.0)
-                retry_delay = (
-                    float(retry_delay_val) if retry_delay_val is not None else 1.0
-                )
-                if retry_delay < 0:
-                    retry_delay = 1.0
-            except (ValueError, TypeError):
-                retry_delay = 1.0
+            max_retries = self.config.get("max_retries", 3)
+            retry_delay = self.config.get("retry_delay", 1.0)
 
             # 解析可重试状态码（直接从 list 类型配置获取）
             retryable_codes = self.config.get("retryable_status_codes", [])
@@ -369,7 +354,7 @@ class GrokSearchPlugin(Star):
                     attempts += 1
                     if not use_retry or attempts > max_retries:
                         return {"ok": False, "error": str(last_exc)}
-                    await asyncio.sleep(retry_delay)
+                    await asyncio.sleep(retry_delay * attempts)
 
         # 否则使用 HTTP 客户端向外部 Grok API 发起请求
         try:

--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ import shutil
 from pathlib import Path
 
 import aiohttp
+import asyncio
+import json
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, filter
@@ -27,6 +29,15 @@ from .grok_client import (
 
 PLUGIN_NAME = "astrbot_plugin_grok_web_search"
 
+# 默认系统提示词（要求返回 JSON 格式）
+DEFAULT_JSON_SYSTEM_PROMPT = (
+    "You are a web research assistant. Use live web search/browsing when answering. "
+    "Return ONLY a single JSON object with keys: "
+    "content (string), sources (array of objects with url/title/snippet when possible). "
+    "Keep content concise and evidence-backed. "
+    "IMPORTANT: Do NOT use Markdown formatting in the content field - use plain text only."
+)
+
 
 class GrokSearchPlugin(Star):
     def __init__(self, context: Context, config: dict = None):
@@ -36,7 +47,15 @@ class GrokSearchPlugin(Star):
 
     async def initialize(self):
         """插件初始化：验证配置并处理 Skill 安装"""
-        self._validate_config()
+        # 如果启用使用 AstrBot 自带供应商，则推迟创建会话和 Skill 安装
+        if self.config.get("use_builtin_provider", False):
+            logger.info(
+                f"[{PLUGIN_NAME}] use_builtin_provider enabled, delaying full initialization until AstrBot is loaded"
+            )
+            return
+
+        # 仅在使用外部 HTTP 客户端时校验 base_url/api_key
+        await self._validate_config()
 
         # 根据配置决定是否创建复用的 HTTP 会话
         if self.config.get("reuse_session", False):
@@ -50,14 +69,47 @@ class GrokSearchPlugin(Star):
         else:
             self._uninstall_skill()
 
-    def _validate_config(self):
-        """验证必要配置"""
+    async def _validate_config(self):
+        """验证必要配置，并通过 v1/models 接口检查连通性"""
         base_url = normalize_base_url(self.config.get("base_url", ""))
         api_key = normalize_api_key(self.config.get("api_key", ""))
         if not base_url:
-            logger.warning(f"[{PLUGIN_NAME}] 缺少 base_url 配置")
+            logger.warning(f"[{PLUGIN_NAME}] 缺少 base_url 配置，请在插件设置中填写 Grok API 端点")
+            return
         if not api_key:
-            logger.warning(f"[{PLUGIN_NAME}] 缺少 api_key 配置")
+            logger.warning(f"[{PLUGIN_NAME}] 缺少 api_key 配置，请在插件设置中填写 API 密钥")
+            return
+
+        # 通过 v1/models 接口验证连通性和密钥有效性
+        models_url = f"{base_url}/v1/models"
+        headers = {"Authorization": f"Bearer {api_key}"}
+        extra_headers = self._parse_json_config("extra_headers")
+        if extra_headers:
+            protected = {"authorization", "content-type"}
+            for key, value in extra_headers.items():
+                if str(key).lower() not in protected:
+                    headers[str(key)] = str(value)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    models_url,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status == 401:
+                        logger.warning(f"[{PLUGIN_NAME}] API 密钥无效（401），请检查 api_key 配置")
+                    elif resp.status == 403:
+                        logger.warning(f"[{PLUGIN_NAME}] API 密钥权限不足（403），请检查 api_key 权限")
+                    elif resp.status == 404:
+                        logger.warning(f"[{PLUGIN_NAME}] v1/models 端点不存在（404），请检查 base_url 配置是否正确")
+                    elif resp.status != 200:
+                        logger.warning(f"[{PLUGIN_NAME}] API 连通性检查返回 HTTP {resp.status}，请确认配置")
+                    else:
+                        logger.info(f"[{PLUGIN_NAME}] API 连通性检查通过")
+        except aiohttp.ClientError as e:
+            logger.warning(f"[{PLUGIN_NAME}] API 连通性检查失败（网络错误）: {e}，请检查 base_url 配置")
+        except asyncio.TimeoutError:
+            logger.warning(f"[{PLUGIN_NAME}] API 连通性检查超时，请检查 base_url 是否可达")
 
     def _get_skills_path(self) -> Path:
         """获取 skills 目录路径"""
@@ -149,7 +201,7 @@ class GrokSearchPlugin(Star):
         persistent_dir = self._get_skill_persistent_path()
 
         try:
-            # 更新持久化目录（可能有新版本）
+            # 更新持久化目录
             if persistent_dir.exists():
                 shutil.rmtree(persistent_dir)
             shutil.move(str(source_dir), str(persistent_dir))
@@ -174,8 +226,20 @@ class GrokSearchPlugin(Star):
             return result
         return {}
 
-    async def _do_search(self, query: str) -> dict:
-        """执行搜索"""
+    async def _do_search(
+        self,
+        query: str,
+        system_prompt: str | None = None,
+        use_retry: bool = False,
+        umo: str | None = None,
+    ) -> dict:
+        """执行搜索
+
+        Args:
+            query: 搜索查询内容
+            system_prompt: 自定义系统提示词，为 None 时使用默认提示词
+            use_retry: 是否启用重试功能（仅指令调用时启用）
+        """
         # 安全解析 timeout 配置
         try:
             timeout_val = self.config.get("timeout_seconds", 60)
@@ -196,18 +260,135 @@ class GrokSearchPlugin(Star):
         except (ValueError, TypeError):
             thinking_budget = 32000
 
-        return await grok_search(
-            query=query,
-            base_url=self.config.get("base_url", ""),
-            api_key=self.config.get("api_key", ""),
-            model=self.config.get("model", "grok-4-fast"),
-            timeout=timeout,
-            enable_thinking=self.config.get("enable_thinking", True),
-            thinking_budget=thinking_budget,
-            extra_body=self._parse_json_config("extra_body"),
-            extra_headers=self._parse_json_config("extra_headers"),
-            session=self._session,
-        )
+        # 重试配置（仅指令调用时使用）
+        max_retries = 0
+        retry_delay = 1.0
+        retryable_status_codes = None
+        if use_retry:
+            try:
+                max_retries_val = self.config.get("max_retries", 3)
+                max_retries = int(max_retries_val) if max_retries_val is not None else 3
+                if max_retries < 0:
+                    max_retries = 3
+            except (ValueError, TypeError):
+                max_retries = 3
+
+            try:
+                retry_delay_val = self.config.get("retry_delay", 1.0)
+                retry_delay = (
+                    float(retry_delay_val) if retry_delay_val is not None else 1.0
+                )
+                if retry_delay < 0:
+                    retry_delay = 1.0
+            except (ValueError, TypeError):
+                retry_delay = 1.0
+
+            # 解析可重试状态码（直接从 list 类型配置获取）
+            retryable_codes = self.config.get("retryable_status_codes", [])
+            if retryable_codes and isinstance(retryable_codes, list):
+                retryable_status_codes = set(retryable_codes)
+
+        # 自定义系统提示词
+        custom_prompt = self.config.get("custom_system_prompt", "")
+        if custom_prompt and isinstance(custom_prompt, str) and custom_prompt.strip():
+            # 如果有自定义提示词且没有传入其他提示词，使用配置中的自定义提示词
+            if system_prompt is None:
+                system_prompt = custom_prompt.strip()
+        # 如果仍然没有系统提示词，使用默认的 JSON 系统提示词
+        if system_prompt is None:
+            system_prompt = DEFAULT_JSON_SYSTEM_PROMPT
+        # 如果启用了使用 AstrBot 自带供应商，通过 AstrBot provider 接口调用
+        if self.config.get("use_builtin_provider", False):
+            attempts = 0
+            last_exc = None
+            while True:
+                try:
+                    # 严格按配置获取 provider
+                    configured_provider_id = self.config.get("provider", "")
+                    if not configured_provider_id:
+                        return {
+                            "ok": False,
+                            "error": "启用了内置供应商但未选择供应商，请在插件设置中选择一个 LLM 供应商",
+                        }
+                    prov = self.context.get_provider_by_id(configured_provider_id)
+                    if not prov:
+                        return {
+                            "ok": False,
+                            "error": f"未找到配置的供应商: {configured_provider_id}",
+                        }
+
+                    provider_id = prov.meta().id
+
+                    llm_resp = await self.context.llm_generate(
+                        chat_provider_id=provider_id,
+                        prompt=query,
+                        system_prompt=system_prompt,
+                    )
+
+                    text = llm_resp.completion_text or ""
+                    try:
+                        parsed = json.loads(text)
+                        content = str(parsed.get("content", ""))
+                        raw_sources = parsed.get("sources", [])
+                        # 归一化 sources 结构
+                        sources = []
+                        if isinstance(raw_sources, list):
+                            for item in raw_sources:
+                                if isinstance(item, dict) and item.get("url"):
+                                    sources.append(
+                                        {
+                                            "url": str(item.get("url")),
+                                            "title": str(item.get("title") or ""),
+                                            "snippet": str(item.get("snippet") or ""),
+                                        }
+                                    )
+                        return {
+                            "ok": True,
+                            "content": content,
+                            "sources": sources,
+                            "elapsed_ms": 0,
+                            "retries": attempts,
+                            "raw": text,
+                        }
+                    except Exception:
+                        return {
+                            "ok": False,
+                            "error": "提供商返回内容不是有效的 JSON",
+                            "raw": text,
+                        }
+
+                except Exception as e:
+                    last_exc = e
+                    attempts += 1
+                    if not use_retry or attempts > max_retries:
+                        return {"ok": False, "error": str(last_exc)}
+                    await asyncio.sleep(retry_delay)
+
+        # 否则使用 HTTP 客户端向外部 Grok API 发起请求
+        try:
+            result = await grok_search(
+                query=query,
+                base_url=self.config.get("base_url", ""),
+                api_key=self.config.get("api_key", ""),
+                model=self.config.get("model", "grok-4-fast"),
+                timeout=timeout,
+                enable_thinking=self.config.get("enable_thinking", True),
+                thinking_budget=thinking_budget,
+                extra_body=self._parse_json_config("extra_body"),
+                extra_headers=self._parse_json_config("extra_headers"),
+                session=self._session,
+                system_prompt=system_prompt,
+                max_retries=max_retries,
+                retry_delay=retry_delay,
+                retryable_status_codes=retryable_status_codes,
+            )
+        except Exception as e:
+            logger.error(f"[{PLUGIN_NAME}] API 调用异常: {e}")
+            return {"ok": False, "error": f"API 调用异常: {e}"}
+
+        if not result.get("ok"):
+            logger.warning(f"[{PLUGIN_NAME}] API 调用失败: {result.get('error', '未知错误')}")
+        return result
 
     def _format_result(self, result: dict) -> str:
         """格式化搜索结果为用户友好的消息"""
@@ -236,7 +417,12 @@ class GrokSearchPlugin(Star):
                 else:
                     lines.append(f"  {i}. {url}")
 
-        lines.append(f"\n(耗时: {elapsed}ms)")
+        # 显示耗时和重试次数
+        retry_info = ""
+        retries = result.get("retries", 0)
+        if retries > 0:
+            retry_info = f"，重试 {retries} 次"
+        lines.append(f"\n(耗时: {elapsed}ms{retry_info})")
 
         return "\n".join(lines)
 
@@ -275,19 +461,44 @@ class GrokSearchPlugin(Star):
 
     def _help_text(self) -> str:
         """返回帮助文本"""
-        return """Grok 联网搜索
+        use_builtin = self.config.get("use_builtin_provider", False)
+        mode = "AstrBot 自带" if use_builtin else "自定义"
+        provider_id = self.config.get("provider", "") or "未配置"
+        model = (
+            "由供应商决定"
+            if use_builtin
+            else (self.config.get("model", "grok-4-fast") or "默认")
+        )
+        has_custom_prompt = bool(
+            (self.config.get("custom_system_prompt", "") or "").strip()
+        )
+        if has_custom_prompt:
+            prompt_info = "自定义"
+        else:
+            prompt_info = "内置中文（/grok 指令）/ 内置英文 JSON（LLM Tool）"
 
-用法: /grok <搜索内容>
-
-示例:
-  /grok Python 3.12 有什么新特性
-  /grok 最新的 AI 新闻
-  /grok React 19 发布了吗
-
-功能:
-  - 实时联网搜索
-  - 返回综合答案和来源链接
-  - 支持 LLM 自动调用"""
+        return (
+            "Grok 联网搜索\n"
+            "\n"
+            "用法:\n"
+            "  /grok help           显示此帮助\n"
+            "  /grok <搜索内容>     执行联网搜索\n"
+            "\n"
+            "示例:\n"
+            "  /grok Python 3.12 有什么新特性\n"
+            "  /grok 最新的 AI 新闻\n"
+            "  /grok React 19 发布了吗\n"
+            "\n"
+            "调用方式:\n"
+            "  - /grok 指令：直接搜索并返回结果\n"
+            "  - LLM Tool：模型自动调用 grok_web_search\n"
+            "\n"
+            f"当前配置:\n"
+            f"  供应商来源: {mode}\n"
+            f"  供应商: {provider_id}\n"
+            f"  模型: {model}\n"
+            f"  系统提示词: {prompt_info}"
+        )
 
     @filter.command("grok")
     async def grok_cmd(self, event: AstrMessageEvent, query: str = ""):
@@ -299,7 +510,27 @@ class GrokSearchPlugin(Star):
             yield event.plain_result(self._help_text())
             return
 
-        result = await self._do_search(query)
+        # 优先使用自定义提示词，未设置则使用内置中文提示词
+        custom_prompt = self.config.get("custom_system_prompt", "")
+        if custom_prompt and isinstance(custom_prompt, str) and custom_prompt.strip():
+            cmd_system_prompt = custom_prompt.strip()
+        else:
+            cmd_system_prompt = (
+                "你是一个网络研究助手。请使用实时网络搜索/浏览来回答问题。"
+                "请务必使用中文回复。"
+                "如果有专有名词或技术术语，可以直接使用原词，或者在中文旁边加个方括号把原词写在里面，例如：人工智能[AI]。"
+                "只返回一个 JSON 对象，包含以下字段："
+                "content（字符串，综合答案），sources（数组，包含 url/title/snippet 的来源对象）。"
+                "内容要简洁且有据可依。"
+                "重要：content 字段中不要使用 Markdown 格式，只使用纯文本。"
+            )
+
+        result = await self._do_search(
+            query,
+            system_prompt=cmd_system_prompt,
+            use_retry=True,
+            umo=event.unified_msg_origin,
+        )
         yield event.plain_result(self._format_result(result))
 
     @filter.llm_tool(name="grok_web_search")
@@ -311,7 +542,9 @@ class GrokSearchPlugin(Star):
         Args:
             query(string): 搜索查询内容，应该是清晰具体的问题或关键词
         """
-        result = await self._do_search(query)
+        result = await self._do_search(
+            query, use_retry=True, umo=event.unified_msg_origin
+        )
         return self._format_result_for_llm(result)
 
     @filter.on_llm_request()
@@ -327,6 +560,31 @@ class GrokSearchPlugin(Star):
 
         if tool_set:
             tool_set.remove_tool("grok_web_search")
+
+    @filter.on_astrbot_loaded()
+    async def on_astrbot_loaded(self):
+        """当 AstrBot 初始化完成后执行的钩子：在启用了自带供应商时完成插件的剩余初始化工作"""
+        try:
+            if not self.config.get("use_builtin_provider", False):
+                return
+
+            logger.info(f"[{PLUGIN_NAME}] AstrBot 已初始化，继续完成插件初始化")
+
+            # 创建复用的 HTTP 会话（如果配置要求）
+            if self.config.get("reuse_session", False) and (
+                self._session is None or self._session.closed
+            ):
+                self._session = aiohttp.ClientSession()
+
+            # 迁移并根据 enable_skill 安装或卸载 Skill
+            self._migrate_skill_to_persistent()
+            if self.config.get("enable_skill", False):
+                self._install_skill()
+            else:
+                self._uninstall_skill()
+
+        except Exception as e:
+            logger.error(f"[{PLUGIN_NAME}] on_astrbot_loaded 处理失败: {e}")
 
     async def terminate(self):
         """插件销毁：关闭 HTTP 会话"""

--- a/main.py
+++ b/main.py
@@ -66,10 +66,14 @@ class GrokSearchPlugin(Star):
         base_url = normalize_base_url(self.config.get("base_url", ""))
         api_key = normalize_api_key(self.config.get("api_key", ""))
         if not base_url:
-            logger.warning(f"[{PLUGIN_NAME}] 缺少 base_url 配置，请在插件设置中填写 Grok API 端点")
+            logger.warning(
+                f"[{PLUGIN_NAME}] 缺少 base_url 配置，请在插件设置中填写 Grok API 端点"
+            )
             return
         if not api_key:
-            logger.warning(f"[{PLUGIN_NAME}] 缺少 api_key 配置，请在插件设置中填写 API 密钥")
+            logger.warning(
+                f"[{PLUGIN_NAME}] 缺少 api_key 配置，请在插件设置中填写 API 密钥"
+            )
             return
 
         # 通过 v1/models 接口验证连通性和密钥有效性
@@ -89,19 +93,31 @@ class GrokSearchPlugin(Star):
                     timeout=aiohttp.ClientTimeout(total=10),
                 ) as resp:
                     if resp.status == 401:
-                        logger.warning(f"[{PLUGIN_NAME}] API 密钥无效（401），请检查 api_key 配置")
+                        logger.warning(
+                            f"[{PLUGIN_NAME}] API 密钥无效（401），请检查 api_key 配置"
+                        )
                     elif resp.status == 403:
-                        logger.warning(f"[{PLUGIN_NAME}] API 密钥权限不足（403），请检查 api_key 权限")
+                        logger.warning(
+                            f"[{PLUGIN_NAME}] API 密钥权限不足（403），请检查 api_key 权限"
+                        )
                     elif resp.status == 404:
-                        logger.warning(f"[{PLUGIN_NAME}] v1/models 端点不存在（404），请检查 base_url 配置是否正确")
+                        logger.warning(
+                            f"[{PLUGIN_NAME}] v1/models 端点不存在（404），请检查 base_url 配置是否正确"
+                        )
                     elif resp.status != 200:
-                        logger.warning(f"[{PLUGIN_NAME}] API 连通性检查返回 HTTP {resp.status}，请确认配置")
+                        logger.warning(
+                            f"[{PLUGIN_NAME}] API 连通性检查返回 HTTP {resp.status}，请确认配置"
+                        )
                     else:
                         logger.info(f"[{PLUGIN_NAME}] API 连通性检查通过")
         except aiohttp.ClientError as e:
-            logger.warning(f"[{PLUGIN_NAME}] API 连通性检查失败（网络错误）: {e}，请检查 base_url 配置")
+            logger.warning(
+                f"[{PLUGIN_NAME}] API 连通性检查失败（网络错误）: {e}，请检查 base_url 配置"
+            )
         except asyncio.TimeoutError:
-            logger.warning(f"[{PLUGIN_NAME}] API 连通性检查超时，请检查 base_url 是否可达")
+            logger.warning(
+                f"[{PLUGIN_NAME}] API 连通性检查超时，请检查 base_url 是否可达"
+            )
 
     def _get_skills_path(self) -> Path:
         """获取 skills 目录路径"""
@@ -378,7 +394,9 @@ class GrokSearchPlugin(Star):
             return {"ok": False, "error": f"API 调用异常: {e}"}
 
         if not result.get("ok"):
-            logger.warning(f"[{PLUGIN_NAME}] API 调用失败: {result.get('error', '未知错误')}")
+            logger.warning(
+                f"[{PLUGIN_NAME}] API 调用失败: {result.get('error', '未知错误')}"
+            )
         return result
 
     def _format_result(self, result: dict) -> str:
@@ -532,9 +550,7 @@ class GrokSearchPlugin(Star):
         Args:
             query(string): 搜索查询内容，应该是清晰具体的问题或关键词
         """
-        result = await self._do_search(
-            query, use_retry=True
-        )
+        result = await self._do_search(query, use_retry=True)
         return self._format_result_for_llm(result)
 
     @filter.on_llm_request()

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_grok_web_search
 display_name: Grok联网搜索
 desc: 通过 Grok API 进行实时联网搜索，返回综合答案和来源链接，支持指令，LLM Tool和skills调用。
-version: v1.0.4
+version: v1.0.5
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_grok_web_search


### PR DESCRIPTION
新增功能：
- 新增 use_builtin_provider 配置项，支持使用 AstrBot 自带供应商
- 新增 provider 配置项，选择已配置的 LLM 供应商
- 新增 max_retries/retry_delay/retryable_status_codes 重试配置
- 新增 custom_system_prompt 自定义系统提示词（支持多行编辑器）
- /grok 指令使用独立中文系统提示词，要求中文回复
- /grok help 显示当前配置状态（供应商、模型、提示词类型）
- 支持延迟初始化：启用内置供应商时在 AstrBot 加载完成后初始化

改进：
- 启用内置供应商时自动使用供应商默认模型和参数
- 重试功能仅对 /grok 指令和 LLM Tool 启用
- retryable_status_codes 仅对自定义 HTTP 客户端生效
- 配置项按功能分组排序

## Summary by Sourcery

为 AstrBot 的内置 Provider 增加延迟初始化、可配置重试逻辑，以及用于 Grok 网页搜索的可自定义系统提示词，并改进连接校验和文档。

New Features:
- 新增配置项，用于启用 AstrBot 的内置 Provider，并为 Grok 网页搜索选择已配置的 LLM Provider。
- 为 Grok 搜索请求新增可配置的重试选项（最大重试次数、延迟、可重试的 HTTP 状态码）。
- 支持自定义系统提示词以及 `/grok` 命令专用的中文系统提示词，并通过 `/grok help` 展示当前配置状态。
- 暴露 AstrBot 的 “loaded hook”，在使用内置 Provider 时可以延迟插件初始化。

Enhancements:
- 通过 `v1/models` 端点验证外部 Grok API 的连通性，并改进配置错误场景下的日志记录。
- 允许省略 model 字段，使 Provider 或端点可以使用其默认模型和参数。
- 为 HTTP 客户端请求和内置 Provider 调用实现结构化的重试处理，并在格式化结果中展示重试次数。
- 优化技能安装和迁移逻辑，使完整初始化仅在基于 Provider 和技能配置确有需要时才执行。

Documentation:
- 重构 README 中的配置内容，将其分组组织，并记录新的 Provider、重试和系统提示词选项，包括 `/grok help` 的行为以及内置 Provider 与自定义 Provider 之间重试机制的差异。
- 新增 1.0.5 版本更新日志条目，说明新的配置选项和行为变更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for using AstrBot’s built‑in providers with delayed initialization, configurable retry logic, and customizable system prompts for Grok web search, while improving connection validation and documentation.

New Features:
- Introduce configuration to use AstrBot’s built‑in provider and select a configured LLM provider for Grok web search.
- Add configurable retry options (max retries, delay, retryable HTTP status codes) for Grok search requests.
- Support custom system prompts and a dedicated Chinese system prompt for the `/grok` command, with `/grok help` exposing current configuration state.
- Expose an AstrBot loaded hook to delay plugin initialization when using the built‑in provider.

Enhancements:
- Validate external Grok API connectivity via the `v1/models` endpoint and improve logging for misconfiguration cases.
- Allow omitting the model field so providers or endpoints can use their default model and parameters.
- Implement structured retry handling for HTTP client requests and built‑in provider calls, and surface retry count in formatted results.
- Optimize skill installation and migration so full initialization only runs when needed based on provider and skill configuration.

Documentation:
- Restructure README configuration into grouped sections and document new provider, retry, and system prompt options, including `/grok help` behavior and retry differences between built‑in and custom providers.
- Add a 1.0.5 changelog entry describing the new configuration options and behavior changes.

</details>

新特性：
- 引入配置项以使用 AstrBot 内置提供商，并为网页搜索选择一个已配置的 LLM 提供商。
- 为 Grok 请求增加可配置的重试行为，包括最大重试次数、重试间隔以及可重试的 HTTP 状态码。
- 为 `/grok` 命令支持自定义系统提示，并单独支持中文系统提示行为，并可通过 `/grok help` 显示当前状态。
- 当使用内置提供商时，延迟插件初始化直到 AstrBot 完全加载完毕，并暴露 AstrBot 加载完成的钩子（hook）。

增强：
- 通过 `v1/models` 端点验证外部 Grok API 的连通性，并对常见配置问题进行详细日志记录。
- 允许提供商或端点使用其自身的默认模型，使请求中的 model 字段变为可选。
- 为 HTTP 客户端请求和内置提供商调用实现结构化的重试逻辑，并在格式化结果中展示重试次数。
- 优化技能安装/迁移流程，并仅在根据提供商配置确有需要时才执行完整初始化。

文档：
- 在 README 中记录新的提供商、重试和系统提示配置，并以分组章节进行说明。
- 更新 README 中关于 `/grok help` 的使用说明，并描述内置提供商与自定义提供商之间新的重试行为差异。
- 添加 1.0.5 版本的更新日志条目，说明新的配置选项和行为变化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 AstrBot 的内置 Provider 增加延迟初始化、可配置重试逻辑，以及用于 Grok 网页搜索的可自定义系统提示词，并改进连接校验和文档。

New Features:
- 新增配置项，用于启用 AstrBot 的内置 Provider，并为 Grok 网页搜索选择已配置的 LLM Provider。
- 为 Grok 搜索请求新增可配置的重试选项（最大重试次数、延迟、可重试的 HTTP 状态码）。
- 支持自定义系统提示词以及 `/grok` 命令专用的中文系统提示词，并通过 `/grok help` 展示当前配置状态。
- 暴露 AstrBot 的 “loaded hook”，在使用内置 Provider 时可以延迟插件初始化。

Enhancements:
- 通过 `v1/models` 端点验证外部 Grok API 的连通性，并改进配置错误场景下的日志记录。
- 允许省略 model 字段，使 Provider 或端点可以使用其默认模型和参数。
- 为 HTTP 客户端请求和内置 Provider 调用实现结构化的重试处理，并在格式化结果中展示重试次数。
- 优化技能安装和迁移逻辑，使完整初始化仅在基于 Provider 和技能配置确有需要时才执行。

Documentation:
- 重构 README 中的配置内容，将其分组组织，并记录新的 Provider、重试和系统提示词选项，包括 `/grok help` 的行为以及内置 Provider 与自定义 Provider 之间重试机制的差异。
- 新增 1.0.5 版本更新日志条目，说明新的配置选项和行为变更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for using AstrBot’s built‑in providers with delayed initialization, configurable retry logic, and customizable system prompts for Grok web search, while improving connection validation and documentation.

New Features:
- Introduce configuration to use AstrBot’s built‑in provider and select a configured LLM provider for Grok web search.
- Add configurable retry options (max retries, delay, retryable HTTP status codes) for Grok search requests.
- Support custom system prompts and a dedicated Chinese system prompt for the `/grok` command, with `/grok help` exposing current configuration state.
- Expose an AstrBot loaded hook to delay plugin initialization when using the built‑in provider.

Enhancements:
- Validate external Grok API connectivity via the `v1/models` endpoint and improve logging for misconfiguration cases.
- Allow omitting the model field so providers or endpoints can use their default model and parameters.
- Implement structured retry handling for HTTP client requests and built‑in provider calls, and surface retry count in formatted results.
- Optimize skill installation and migration so full initialization only runs when needed based on provider and skill configuration.

Documentation:
- Restructure README configuration into grouped sections and document new provider, retry, and system prompt options, including `/grok help` behavior and retry differences between built‑in and custom providers.
- Add a 1.0.5 changelog entry describing the new configuration options and behavior changes.

</details>

</details>