### PR TITLE
修复 /grok 指令空格解析并新增合并转发

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 本项目遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)。
 
+## [1.4.1] - 2026-05-05
+
+### Added
+- **合并转发**：`send_as_forward` 配置项，OneBot v11/aiocqhttp 平台下 `/grok` 结果以合并转发发送，其他平台自动降级
+- **配置迁移**：`_migrate_legacy_config()` 自动将旧版平铺配置迁移到新版分组结构
+
+### Changed
+- **配置 Schema 重构**：平铺式配置重组为分组结构（`provider_settings` / `connection_settings` / `request_settings` / `output_settings` / `tool_settings` / `advanced_settings`），旧版平铺键保留 `invisible` 以兼容
+- **配置读取统一**：`_cfg()` 方法按 `CONFIG_PATHS` 映射分层读取配置，带默认值回退
+- **图片 Base64 转换重构**：`_append_image_base64()` 统一处理 Image 组件、base64://、data:image/、http(s)://、本地路径五种来源
+- **引用消息解析增强**：优先使用 astrbot 新版 `quoted_message_parser`，失败时回退 `chain_parser`
+
 ## [1.4.0] - 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 | `use_builtin_provider` | bool | 否 | 是否使用 AstrBot 自带供应商（默认: false） |
 | `provider` | string | 条件 | 选择已配置的 LLM 供应商（启用自带供应商时必填） |
 | `model` | string | 否 | 模型名称（默认: grok-4.1-fast，启用自带供应商时使用供应商默认模型） |
+| `use_responses_api` | bool | 否 | 使用 xAI Responses API（仅官方 API 支持，非官方端点兼容性不佳） |
 
 ### 连接设置
 
@@ -45,8 +46,9 @@
 | `api_key` | string | 条件 | API 密钥（使用自定义供应商时必填） |
 | `timeout_seconds` | int | 否 | 超时时间（默认: 60 秒） |
 | `reuse_session` | bool | 否 | 是否复用 HTTP 会话（高频调用场景可开启，默认: false） |
+| `proxy` | string | 否 | HTTP 代理地址（例如: http://127.0.0.1:7890） |
 
-### 行为设置
+### 请求设置
 
 | 配置项 | 类型 | 必填 | 说明 |
 |--------|------|------|------|
@@ -55,6 +57,7 @@
 | `max_retries` | int | 否 | 最大重试次数（默认: 3） |
 | `retry_delay` | float | 否 | 重试间隔时间（默认: 1 秒），429 时优先使用 Retry-After 头 |
 | `retryable_status_codes` | list | 否 | 可重试的 HTTP 状态码（默认: [429, 500, 502, 503, 504]） |
+| `custom_system_prompt` | text | 否 | 自定义系统提示词（留空使用默认提示词） |
 
 ### 输出设置
 
@@ -62,17 +65,16 @@
 |--------|------|------|------|
 | `show_sources` | bool | 否 | 是否显示来源 URL（默认: false） |
 | `render_as_image` | bool | 否 | 是否将搜索结果渲染为图片卡片（默认: false） |
+| `send_as_forward` | bool | 否 | 将 `/grok` 结果以合并转发发送，仅 OneBot v11/aiocqhttp 支持，其他平台自动降级（默认: false） |
 | `card_theme` | string | 否 | 卡片主题：auto（按时间自动）/ dark / light（默认: auto） |
 | `max_sources` | int | 否 | 最大返回来源数量，0 表示不限制（默认: 5） |
-| `custom_system_prompt` | text | 否 | 自定义系统提示词（留空使用默认提示词） |
 
-### Skill 与 API 模式
+### 工具设置
 
 | 配置项 | 类型 | 必填 | 说明 |
 |--------|------|------|------|
 | `enable_fetch` | bool | 否 | 启用网页抓取工具（默认: false），关闭时工具不会注册 |
 | `enable_skill` | bool | 否 | 安装 Skill 到 skills 目录（启用后所有 LLM Tool 不会注册） |
-| `use_responses_api` | bool | 否 | 使用 xAI Responses API（仅官方 API 支持，非官方端点兼容性不佳） |
 
 > 工具开关在插件初始化时生效，修改配置后插件会自动重载卸载工具。
 
@@ -85,6 +87,8 @@
 - **Markdown 支持**：标题、列表、代码块、引用、**粗体**、`行内代码`
 - **来源链接**：以单独文本消息发送（可点击/复制）
 
+启用 `send_as_forward` 后，OneBot v11/aiocqhttp 平台会优先将 `/grok` 结果作为合并转发发送。
+
 #### 效果展示
 
 | 深色主题 | 浅色主题 |
@@ -93,7 +97,7 @@
 
 **字体说明**：首次启用时自动从清华镜像下载 Sarasa Term Slab SC 字体。也可在 `data/plugin_data/astrbot_plugin_grok_web_search/font/` 目录放入自定义 `.ttf` 字体文件。
 
-### HTTP 扩展
+### 扩展参数
 
 | 配置项 | 类型 | 必填 | 说明 |
 |--------|------|------|------|

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,164 +1,348 @@
 {
+  "provider_settings": {
+    "type": "object",
+    "description": "供应商设置",
+    "hint": "选择使用 AstrBot 自带供应商或自定义 Grok API",
+    "items": {
+      "use_builtin_provider": {
+        "type": "bool",
+        "description": "是否使用 AstrBot 自带供应商",
+        "hint": "启用后将使用已配置的 LLM 供应商，无需配置模型参数",
+        "default": false
+      },
+      "provider": {
+        "_special": "select_provider",
+        "type": "string",
+        "description": "选择要使用的 LLM 供应商",
+        "hint": "仅当启用自带供应商时生效，选择已配置的 LLM 供应商",
+        "default": ""
+      },
+      "model": {
+        "type": "string",
+        "description": "模型名称",
+        "hint": "选择要使用的 Grok 模型",
+        "default": "grok-4.1-fast"
+      },
+      "use_responses_api": {
+        "type": "bool",
+        "description": "使用 /v1/responses 接口",
+        "hint": "仅适用于 xAI 官方 API，非官方/第三方服务对此接口支持不完善，可能导致请求失败",
+        "default": false
+      }
+    }
+  },
+  "connection_settings": {
+    "type": "object",
+    "description": "连接设置",
+    "hint": "自定义供应商的连接参数",
+    "items": {
+      "base_url": {
+        "type": "string",
+        "description": "Grok API 端点 URL",
+        "hint": "使用自定义供应商时必填，例如: https://api.example.com，会自动补全 /v1/chat/completions 或 /v1/responses"
+      },
+      "api_key": {
+        "type": "string",
+        "description": "Grok API 密钥",
+        "hint": "使用自定义供应商时必填，你的 API Key"
+      },
+      "timeout_seconds": {
+        "type": "int",
+        "description": "请求超时时间（秒）",
+        "hint": "控制每次请求的最大等待时间",
+        "default": 60
+      },
+      "reuse_session": {
+        "type": "bool",
+        "description": "是否复用 HTTP 会话",
+        "hint": "高频调用场景可开启以减少连接开销",
+        "default": false
+      },
+      "proxy": {
+        "type": "string",
+        "description": "HTTP 代理地址",
+        "hint": "例如: http://127.0.0.1:7890，留空则不使用代理",
+        "default": ""
+      }
+    }
+  },
+  "request_settings": {
+    "type": "object",
+    "description": "请求设置",
+    "hint": "控制模型请求、重试和提示词",
+    "items": {
+      "enable_thinking": {
+        "type": "bool",
+        "description": "是否开启思考模式",
+        "hint": "允许模型在回答前进行多轮思考",
+        "default": true
+      },
+      "thinking_budget": {
+        "type": "int",
+        "description": "思考 token 预算",
+        "hint": "控制思考阶段可使用的最大 token 数量",
+        "default": 32000
+      },
+      "max_retries": {
+        "type": "int",
+        "description": "最大重试次数",
+        "hint": "请求失败时的最大重试次数",
+        "default": 3,
+        "slider": {
+          "min": 0,
+          "max": 10,
+          "step": 1
+        }
+      },
+      "retry_delay": {
+        "type": "float",
+        "description": "重试间隔时间（秒）",
+        "hint": "基础重试间隔（线性退避），429 错误时优先使用服务端 Retry-After 头",
+        "default": 1.0,
+        "slider": {
+          "min": 0.1,
+          "max": 5,
+          "step": 0.1
+        }
+      },
+      "retryable_status_codes": {
+        "type": "list",
+        "description": "可重试的 HTTP 状态码",
+        "hint": "自定义重试的 HTTP 状态码列表",
+        "default": [
+          429,
+          500,
+          502,
+          503,
+          504
+        ]
+      },
+      "custom_system_prompt": {
+        "type": "text",
+        "description": "自定义系统提示词",
+        "hint": "留空使用默认提示词",
+        "default": "",
+        "editor_mode": true,
+        "editor_language": "markdown",
+        "editor_theme": "vs-dark"
+      }
+    }
+  },
+  "output_settings": {
+    "type": "object",
+    "description": "输出设置",
+    "hint": "控制搜索结果展示方式",
+    "items": {
+      "show_sources": {
+        "type": "bool",
+        "description": "是否在结果中显示来源 URL",
+        "hint": "启用后将在搜索结果中显示来源链接",
+        "default": false
+      },
+      "render_as_image": {
+        "type": "bool",
+        "description": "是否将搜索结果渲染为图片卡片",
+        "hint": "启用后 /grok 指令的结果将以精美图片卡片形式发送，来源链接单独以文本发送",
+        "default": false
+      },
+      "send_as_forward": {
+        "type": "bool",
+        "description": "是否将 /grok 结果以合并转发发送",
+        "hint": "启用过后合并转发消息",
+        "default": false
+      },
+      "card_theme": {
+        "type": "string",
+        "description": "卡片主题",
+        "hint": "auto: 根据系统时间自动切换日/夜模式；dark: 深色；light: 浅色",
+        "default": "auto",
+        "options": [
+          "auto",
+          "dark",
+          "light"
+        ]
+      },
+      "max_sources": {
+        "type": "int",
+        "description": "最大返回来源数量",
+        "hint": "控制返回的来源链接数量，0 表示不限制",
+        "default": 5
+      }
+    }
+  },
+  "tool_settings": {
+    "type": "object",
+    "description": "工具设置",
+    "hint": "控制 LLM Tool 与 Skill 安装",
+    "items": {
+      "enable_fetch": {
+        "type": "bool",
+        "description": "是否启用网页抓取工具",
+        "hint": "启用后 AI 可调用 grok_web_fetch 抓取网页内容",
+        "default": false
+      },
+      "enable_skill": {
+        "type": "bool",
+        "description": "是否安装 Skill 到 skills 目录",
+        "hint": "启用后将安装 Skill 以供 AstrBot 使用，同时禁用 LLM Tool",
+        "default": false
+      }
+    }
+  },
+  "advanced_settings": {
+    "type": "object",
+    "description": "扩展参数",
+    "hint": "向 API 请求追加自定义 JSON 参数和请求头",
+    "items": {
+      "extra_body": {
+        "type": "text",
+        "description": "额外请求体参数（JSON 格式）",
+        "hint": "追加到 API 请求体的 JSON 参数，例如: {\"temperature\": 0.5, \"max_tokens\": 4096}",
+        "default": "",
+        "editor_mode": true,
+        "editor_language": "json",
+        "editor_theme": "vs-dark"
+      },
+      "extra_headers": {
+        "type": "text",
+        "description": "额外请求头（JSON 格式）",
+        "hint": "追加到 HTTP 请求头的 JSON 参数，例如: {\"X-Custom-Header\": \"value\"}",
+        "default": "",
+        "editor_mode": true,
+        "editor_language": "json",
+        "editor_theme": "vs-dark"
+      }
+    }
+  },
   "use_builtin_provider": {
     "type": "bool",
-    "description": "是否使用 AstrBot 自带供应商",
-    "hint": "启用后将使用已配置的 LLM 供应商,无需配置模型参数",
-    "default": false
+    "default": false,
+    "invisible": true
   },
   "provider": {
-    "_special": "select_provider",
     "type": "string",
-    "description": "选择要使用的 LLM 供应商",
-    "hint": "仅当启用自带供应商时生效,选择已配置的 LLM 供应商",
-    "default": ""
+    "default": "",
+    "invisible": true
   },
   "model": {
     "type": "string",
-    "description": "模型名称",
-    "hint": "选择要使用的 Grok 模型",
-    "default": "grok-4.1-fast"
+    "default": "grok-4.1-fast",
+    "invisible": true
   },
   "use_responses_api": {
     "type": "bool",
-    "description": "使用 /v1/responses 接口",
-    "hint": "⚠️ 仅适用于 xAI 官方 API，非官方/第三方服务对此接口支持不完善，可能导致请求失败",
-    "default": false
+    "default": false,
+    "invisible": true
   },
   "base_url": {
     "type": "string",
-    "description": "Grok API 端点 URL",
-    "hint": "使用自定义供应商时必填,例如: https://api.example.com，会自动补全 /v1/chat/completions 或 /v1/responses"
+    "default": "",
+    "invisible": true
   },
   "api_key": {
     "type": "string",
-    "description": "Grok API 密钥",
-    "hint": "使用自定义供应商时必填,你的 API Key"
+    "default": "",
+    "invisible": true
   },
   "timeout_seconds": {
     "type": "int",
-    "description": "请求超时时间（秒）",
-    "hint": "控制每次请求的最大等待时间",
-    "default": 60
+    "default": 60,
+    "invisible": true
   },
   "reuse_session": {
     "type": "bool",
-    "description": "是否复用 HTTP 会话",
-    "hint": "高频调用场景可开启以减少连接开销",
-    "default": false
+    "default": false,
+    "invisible": true
+  },
+  "proxy": {
+    "type": "string",
+    "default": "",
+    "invisible": true
   },
   "enable_thinking": {
     "type": "bool",
-    "description": "是否开启思考模式",
-    "hint": "允许模型在回答前进行多轮思考",
-    "default": true
+    "default": true,
+    "invisible": true
   },
   "thinking_budget": {
     "type": "int",
-    "description": "思考 token 预算",
-    "hint": "控制思考阶段可使用的最大 token 数量",
-    "default": 32000
+    "default": 32000,
+    "invisible": true
   },
   "max_retries": {
     "type": "int",
-    "description": "最大重试次数",
-    "hint": "请求失败时的最大重试次数",
     "default": 3,
-    "slider": {
-      "min": 0,
-      "max": 10,
-      "step": 1
-    }
+    "invisible": true
   },
   "retry_delay": {
     "type": "float",
-    "description": "重试间隔时间（秒）",
-    "hint": "基础重试间隔（线性退避），429 错误时优先使用服务端 Retry-After 头",
     "default": 1.0,
-    "slider": {
-      "min": 0.1,
-      "max": 5,
-      "step": 0.1
-    }
+    "invisible": true
   },
   "retryable_status_codes": {
     "type": "list",
-    "description": "可重试的 HTTP 状态码",
-    "hint": "自定义重试的 HTTP 状态码列表",
     "default": [
       429,
       500,
       502,
       503,
       504
-    ]
-  },
-  "show_sources": {
-    "type": "bool",
-    "description": "是否在结果中显示来源 URL",
-    "hint": "启用后将在搜索结果中显示来源链接",
-    "default": false
-  },
-  "render_as_image": {
-    "type": "bool",
-    "description": "是否将搜索结果渲染为图片卡片",
-    "hint": "启用后 /grok 指令的结果将以精美图片卡片形式发送，来源链接单独以文本发送",
-    "default": false
-  },
-  "card_theme": {
-    "type": "string",
-    "description": "卡片主题",
-    "hint": "auto: 根据系统时间自动切换日/夜模式；dark: 深色；light: 浅色",
-    "default": "auto"
-  },
-  "max_sources": {
-    "type": "int",
-    "description": "最大返回来源数量",
-    "hint": "控制返回的来源链接数量.0 表示不限制",
-    "default": 5
+    ],
+    "invisible": true
   },
   "custom_system_prompt": {
     "type": "text",
-    "description": "自定义系统提示词",
-    "hint": "留空使用默认提示词",
     "default": "",
-    "editor_mode": true,
-    "editor_language": "markdown",
-    "editor_theme": "vs-dark"
-  },
-  "enable_fetch": {
-    "type": "bool",
-    "description": "是否启用网页抓取工具",
-    "hint": "启用后 AI 可调用 grok_web_fetch 抓取网页内容",
-    "default": false
-  },
-  "enable_skill": {
-    "type": "bool",
-    "description": "是否安装 Skill 到 skills 目录",
-    "hint": "启用后将安装 Skill 以供 AstrBot 使用，同时禁用 LLM Tool",
-    "default": false
+    "invisible": true
   },
   "extra_body": {
     "type": "text",
-    "description": "额外请求体参数（JSON 格式）",
-    "hint": "追加到 API 请求体的 JSON 参数，例如: {\"temperature\": 0.5, \"max_tokens\": 4096}",
     "default": "",
-    "editor_mode": true,
-    "editor_language": "json",
-    "editor_theme": "vs-dark"
+    "invisible": true
   },
   "extra_headers": {
     "type": "text",
-    "description": "额外请求头（JSON 格式）",
-    "hint": "追加到 HTTP 请求头的 JSON 参数，例如: {\"X-Custom-Header\": \"value\"}",
     "default": "",
-    "editor_mode": true,
-    "editor_language": "json",
-    "editor_theme": "vs-dark"
+    "invisible": true
   },
-  "proxy": {
+  "show_sources": {
+    "type": "bool",
+    "default": false,
+    "invisible": true
+  },
+  "render_as_image": {
+    "type": "bool",
+    "default": false,
+    "invisible": true
+  },
+  "send_as_forward": {
+    "type": "bool",
+    "default": false,
+    "invisible": true
+  },
+  "card_theme": {
     "type": "string",
-    "description": "HTTP 代理地址",
-    "hint": "例如: http://127.0.0.1:7890，留空则不使用代理",
-    "default": ""
+    "default": "auto",
+    "options": [
+      "auto",
+      "dark",
+      "light"
+    ],
+    "invisible": true
+  },
+  "max_sources": {
+    "type": "int",
+    "default": 5,
+    "invisible": true
+  },
+  "enable_fetch": {
+    "type": "bool",
+    "default": false,
+    "invisible": true
+  },
+  "enable_skill": {
+    "type": "bool",
+    "default": false,
+    "invisible": true
   }
 }

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ import aiohttp
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 from astrbot.api.star import Context, Star
-from astrbot.core.message.components import Forward, Image, Node, Nodes, Reply
+from astrbot.core.message.components import Forward, Image, Node, Nodes, Plain, Reply
 from astrbot.core.star.filter.command import GreedyStr
 from astrbot.core.utils.io import download_image_by_url, file_to_base64
 from astrbot.core.utils.quoted_message.chain_parser import (
@@ -34,6 +34,16 @@ try:
     from astrbot.core.provider.register import llm_tools as _llm_tools_registry
 except ImportError:
     _llm_tools_registry = None
+try:
+    from astrbot.core.utils.quoted_message_parser import (
+        extract_quoted_message_images as _extract_quoted_message_images,
+    )
+    from astrbot.core.utils.quoted_message_parser import (
+        extract_quoted_message_text as _extract_quoted_message_text,
+    )
+except ImportError:
+    _extract_quoted_message_images = None
+    _extract_quoted_message_text = None
 try:
     from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 except ImportError:
@@ -60,6 +70,61 @@ from .tool.tool import (
 )
 
 PLUGIN_NAME = "astrbot_plugin_grok_web_search"
+FORWARD_SENDER_NAME = "Grok搜索助手"
+
+CONFIG_PATHS = {
+    "use_builtin_provider": ("provider_settings", "use_builtin_provider"),
+    "provider": ("provider_settings", "provider"),
+    "model": ("provider_settings", "model"),
+    "use_responses_api": ("provider_settings", "use_responses_api"),
+    "base_url": ("connection_settings", "base_url"),
+    "api_key": ("connection_settings", "api_key"),
+    "timeout_seconds": ("connection_settings", "timeout_seconds"),
+    "reuse_session": ("connection_settings", "reuse_session"),
+    "proxy": ("connection_settings", "proxy"),
+    "enable_thinking": ("request_settings", "enable_thinking"),
+    "thinking_budget": ("request_settings", "thinking_budget"),
+    "max_retries": ("request_settings", "max_retries"),
+    "retry_delay": ("request_settings", "retry_delay"),
+    "retryable_status_codes": ("request_settings", "retryable_status_codes"),
+    "custom_system_prompt": ("request_settings", "custom_system_prompt"),
+    "extra_body": ("advanced_settings", "extra_body"),
+    "extra_headers": ("advanced_settings", "extra_headers"),
+    "show_sources": ("output_settings", "show_sources"),
+    "render_as_image": ("output_settings", "render_as_image"),
+    "send_as_forward": ("output_settings", "send_as_forward"),
+    "card_theme": ("output_settings", "card_theme"),
+    "max_sources": ("output_settings", "max_sources"),
+    "enable_fetch": ("tool_settings", "enable_fetch"),
+    "enable_skill": ("tool_settings", "enable_skill"),
+}
+
+CONFIG_DEFAULTS = {
+    "use_builtin_provider": False,
+    "provider": "",
+    "model": DEFAULT_MODEL,
+    "use_responses_api": False,
+    "base_url": "",
+    "api_key": "",
+    "timeout_seconds": 60,
+    "reuse_session": False,
+    "proxy": "",
+    "enable_thinking": True,
+    "thinking_budget": 32000,
+    "max_retries": 3,
+    "retry_delay": 1.0,
+    "retryable_status_codes": [429, 500, 502, 503, 504],
+    "custom_system_prompt": "",
+    "extra_body": "",
+    "extra_headers": "",
+    "show_sources": False,
+    "render_as_image": False,
+    "send_as_forward": False,
+    "card_theme": "auto",
+    "max_sources": 5,
+    "enable_fetch": False,
+    "enable_skill": False,
+}
 
 
 def _fmt_tokens(n: int) -> str:
@@ -82,14 +147,56 @@ class GrokSearchPlugin(Star):
         self._session: aiohttp.ClientSession | None = None
         self._card_fonts_ready = False
         self._font_init_task: asyncio.Task | None = None
+        self._migrate_legacy_config()
+
+    def _cfg(self, key: str, default=None):
+        path = CONFIG_PATHS.get(key)
+        if path:
+            section = self.config.get(path[0], {})
+            if isinstance(section, dict) and path[1] in section:
+                return section[path[1]]
+        return self.config.get(key, default)
+
+    def _migrate_legacy_config(self) -> None:
+        """Move old flat config values into the grouped schema once."""
+        changed = False
+        for key, path in CONFIG_PATHS.items():
+            if key not in self.config:
+                continue
+
+            default = CONFIG_DEFAULTS.get(key)
+            legacy_value = self.config.get(key)
+            if legacy_value == default:
+                continue
+
+            section = self.config.get(path[0])
+            if not isinstance(section, dict):
+                section = {}
+                self.config[path[0]] = section
+
+            current_value = section.get(path[1], default)
+            if current_value != default:
+                continue
+
+            section[path[1]] = legacy_value
+            self.config[key] = list(default) if isinstance(default, list) else default
+            changed = True
+
+        save_config = getattr(self.config, "save_config", None)
+        if changed and callable(save_config):
+            try:
+                save_config()
+                logger.info(f"[{PLUGIN_NAME}] 已迁移旧版平铺配置到新版分组配置")
+            except Exception as e:
+                logger.warning(f"[{PLUGIN_NAME}] 保存迁移后的配置失败: {e}")
 
     async def _extract_content_from_event(
         self, event: AstrMessageEvent
     ) -> tuple[str | None, list[str]]:
         """Extract text and images from the user's message.
 
-        Reuses AstrBot core's chain_parser for text/image extraction from
-        Reply, Node, Nodes, Forward, etc.
+        Prefer AstrBot core's public quoted_message_parser for Reply/forward
+        fallback parsing. Older cores fall back to chain_parser helpers.
 
         Returns:
             A tuple of (text, images):
@@ -97,49 +204,74 @@ class GrokSearchPlugin(Star):
             - images: list of base64-encoded image strings (without prefix)
         """
         chain = event.get_messages()
+        text: str | None = None
+        image_refs: list[str] = []
 
-        # 使用本体的 chain_parser 提取文本（处理 Reply/Node/Nodes/Forward）
-        text = _extract_text_from_component_chain(chain)
+        use_legacy_parser = True
+        if (
+            _extract_quoted_message_text is not None
+            and _extract_quoted_message_images is not None
+        ):
+            try:
+                text = await _extract_quoted_message_text(event)
+                image_refs = await _extract_quoted_message_images(event)
+                use_legacy_parser = not text and not image_refs
+            except Exception as e:
+                logger.warning(
+                    f"[{PLUGIN_NAME}] quoted_message_parser failed, falling back to chain_parser: {e}"
+                )
 
-        # 使用本体的 chain_parser 提取图片引用，再转为 base64
-        image_refs = _extract_image_refs_from_component_chain(chain)
+        if use_legacy_parser:
+            text = _extract_text_from_component_chain(chain)
+            image_refs = _extract_image_refs_from_component_chain(chain)
+
         images: list[str] = []
         seen: set[str] = set()
 
         # 提取消息链顶层的 Image 组件并转为 base64
         for comp in chain:
             if isinstance(comp, Image):
-                try:
-                    b64 = await comp.convert_to_base64()
-                    if b64 and b64 not in seen:
-                        seen.add(b64)
-                        images.append(b64)
-                except Exception as e:
-                    logger.warning(
-                        f"[{PLUGIN_NAME}] Failed to convert image to base64: {e}"
-                    )
+                await self._append_image_base64(comp, images, seen)
 
         # 将嵌套组件中的图片引用（URL/路径）转为 base64
         for ref in image_refs:
-            try:
-                img = Image.fromURL(ref)
-                b64 = await img.convert_to_base64()
-                if b64 and b64 not in seen:
-                    seen.add(b64)
-                    images.append(b64)
-            except Exception as e:
-                logger.warning(
-                    f"[{PLUGIN_NAME}] Failed to convert image ref to base64: {e}"
-                )
+            await self._append_image_base64(ref, images, seen)
 
         return text, images
+
+    async def _append_image_base64(
+        self,
+        image: Image | str,
+        images: list[str],
+        seen: set[str],
+    ) -> None:
+        try:
+            if isinstance(image, Image):
+                b64 = await image.convert_to_base64()
+            else:
+                image_ref = image.strip()
+                if image_ref.startswith("base64://"):
+                    b64 = image_ref.removeprefix("base64://")
+                elif image_ref.startswith("data:image/"):
+                    b64 = image_ref.split(",", 1)[1] if "," in image_ref else ""
+                elif image_ref.startswith(("http://", "https://")):
+                    b64 = await Image.fromURL(image_ref).convert_to_base64()
+                else:
+                    b64 = await Image(file=image_ref).convert_to_base64()
+
+            b64 = b64.removeprefix("base64://")
+            if b64 and b64 not in seen:
+                seen.add(b64)
+                images.append(b64)
+        except Exception as e:
+            logger.warning(f"[{PLUGIN_NAME}] Failed to convert image to base64: {e}")
 
     def _unregister_disabled_tools(self):
         """根据配置在初始化时直接卸载不需要的 LLM Tool，避免 AI 看到无用工具"""
         if _llm_tools_registry is None:
             return
 
-        if self.config.get("enable_skill", False):
+        if self._cfg("enable_skill", False):
             # Skill 接管，移除所有 LLM Tool
             _llm_tools_registry.remove_func("grok_web_search")
             _llm_tools_registry.remove_func("grok_web_fetch")
@@ -148,7 +280,7 @@ class GrokSearchPlugin(Star):
             )
             return
 
-        if not self.config.get("enable_fetch", False):
+        if not self._cfg("enable_fetch", False):
             _llm_tools_registry.remove_func("grok_web_fetch")
             logger.info(f"[{PLUGIN_NAME}] 网页抓取未启用，已卸载 grok_web_fetch 工具")
 
@@ -158,7 +290,7 @@ class GrokSearchPlugin(Star):
         try:
             from .tool import font_loader
 
-            font_loader.set_proxy(self.config.get("proxy", "") or None)
+            font_loader.set_proxy(self._cfg("proxy", "") or None)
             if get_astrbot_data_path:
                 font_dir = str(
                     Path(get_astrbot_data_path()) / "plugin_data" / PLUGIN_NAME / "font"
@@ -176,7 +308,7 @@ class GrokSearchPlugin(Star):
     async def initialize(self):
         """插件初始化：验证配置并处理 Skill 安装"""
         # 在后台初始化字体，仅在开启图片渲染模式下
-        if self.config.get("render_as_image", False):
+        if self._cfg("render_as_image", False):
             set_card_logger(logger)
             self._font_init_task = asyncio.create_task(
                 asyncio.to_thread(self._init_fonts)
@@ -186,7 +318,7 @@ class GrokSearchPlugin(Star):
         self._unregister_disabled_tools()
 
         # 如果启用使用 AstrBot 自带供应商，则推迟创建会话和 Skill 安装
-        if self.config.get("use_builtin_provider", False):
+        if self._cfg("use_builtin_provider", False):
             logger.info(
                 f"[{PLUGIN_NAME}] use_builtin_provider enabled, delaying full initialization until AstrBot is loaded"
             )
@@ -196,21 +328,21 @@ class GrokSearchPlugin(Star):
         await self._validate_config()
 
         # 根据配置决定是否创建复用的 HTTP 会话
-        if self.config.get("reuse_session", False):
+        if self._cfg("reuse_session", False):
             self._session = aiohttp.ClientSession()
 
         # 首次安装：将插件目录的 skill 移动到持久化目录
         self._migrate_skill_to_persistent()
 
-        if self.config.get("enable_skill", False):
+        if self._cfg("enable_skill", False):
             self._install_skill()
         else:
             self._uninstall_skill()
 
     async def _validate_config(self):
         """验证必要配置，并通过 v1/models 接口检查连通性"""
-        base_url = normalize_base_url(self.config.get("base_url", ""))
-        api_key = normalize_api_key(self.config.get("api_key", ""))
+        base_url = normalize_base_url(self._cfg("base_url", ""))
+        api_key = normalize_api_key(self._cfg("api_key", ""))
         if not base_url:
             logger.warning(
                 f"[{PLUGIN_NAME}] 缺少 base_url 配置，请在插件设置中填写 Grok API 端点"
@@ -228,7 +360,7 @@ class GrokSearchPlugin(Star):
         headers = build_headers(api_key, extra_headers or None)
 
         # 获取代理配置
-        proxy = self.config.get("proxy", "").strip() or None
+        proxy = self._cfg("proxy", "").strip() or None
 
         try:
             async with aiohttp.ClientSession() as session:
@@ -363,7 +495,7 @@ class GrokSearchPlugin(Star):
 
     def _parse_json_config(self, key: str) -> dict:
         """解析 JSON 格式的配置项"""
-        value = self.config.get(key, "")
+        value = self._cfg(key, "")
         if isinstance(value, dict):
             return value
         if isinstance(value, str):
@@ -390,7 +522,7 @@ class GrokSearchPlugin(Star):
         """
         # 安全解析 timeout 配置
         timeout = safe_number(
-            self.config.get("timeout_seconds", 60),
+            self._cfg("timeout_seconds", 60),
             60.0,
             cast=float,
             min_val=0.001,
@@ -398,7 +530,7 @@ class GrokSearchPlugin(Star):
 
         # 安全解析 thinking_budget 配置
         thinking_budget = safe_number(
-            self.config.get("thinking_budget", 32000),
+            self._cfg("thinking_budget", 32000),
             32000,
             cast=int,
             min_val=0,
@@ -409,22 +541,22 @@ class GrokSearchPlugin(Star):
         retry_delay = 1.0
         retryable_status_codes = None
         if use_retry:
-            max_retries = self.config.get("max_retries", 3)
-            retry_delay = self.config.get("retry_delay", 1.0)
+            max_retries = self._cfg("max_retries", 3)
+            retry_delay = self._cfg("retry_delay", 1.0)
 
             # 解析可重试状态码（直接从 list 类型配置获取）
-            retryable_codes = self.config.get("retryable_status_codes", [])
+            retryable_codes = self._cfg("retryable_status_codes", [])
             if retryable_codes and isinstance(retryable_codes, list):
                 retryable_status_codes = set(retryable_codes)
 
         # 自定义系统提示词（传入优先，其次配置，最后默认 JSON 提示词）
         if system_prompt is None:
             system_prompt = resolve_system_prompt(
-                self.config.get("custom_system_prompt", ""),
+                self._cfg("custom_system_prompt", ""),
                 DEFAULT_JSON_SYSTEM_PROMPT,
             )
 
-        if self.config.get("use_builtin_provider", False):
+        if self._cfg("use_builtin_provider", False):
             return await self._do_search_via_builtin_provider(
                 query=query,
                 system_prompt=system_prompt,
@@ -461,7 +593,7 @@ class GrokSearchPlugin(Star):
         while True:
             try:
                 # 严格按配置获取 provider
-                configured_provider_id = self.config.get("provider", "")
+                configured_provider_id = self._cfg("provider", "")
                 if not configured_provider_id:
                     return {
                         "ok": False,
@@ -561,12 +693,12 @@ class GrokSearchPlugin(Star):
     ) -> dict:
         """通过外部 Grok HTTP API 执行搜索。"""
         try:
-            proxy = self.config.get("proxy", "").strip() or None
+            proxy = self._cfg("proxy", "").strip() or None
             common_kwargs = {
                 "query": query,
-                "base_url": self.config.get("base_url", ""),
-                "api_key": self.config.get("api_key", ""),
-                "model": self.config.get("model", DEFAULT_MODEL),
+                "base_url": self._cfg("base_url", ""),
+                "api_key": self._cfg("api_key", ""),
+                "model": self._cfg("model", DEFAULT_MODEL),
                 "timeout": timeout,
                 "extra_body": self._parse_json_config("extra_body"),
                 "extra_headers": self._parse_json_config("extra_headers"),
@@ -579,11 +711,11 @@ class GrokSearchPlugin(Star):
                 "proxy": proxy,
             }
 
-            if self.config.get("use_responses_api", False):
+            if self._cfg("use_responses_api", False):
                 result = await grok_responses_search(**common_kwargs)
             else:
                 result = await grok_search(
-                    enable_thinking=self.config.get("enable_thinking", True),
+                    enable_thinking=self._cfg("enable_thinking", True),
                     thinking_budget=thinking_budget,
                     **common_kwargs,
                 )
@@ -605,9 +737,9 @@ class GrokSearchPlugin(Star):
         with_snippet: bool,
     ) -> list[str]:
         """渲染来源列表，遵循 show_sources / max_sources 配置。"""
-        if not self.config.get("show_sources", False) or not sources:
+        if not self._cfg("show_sources", False) or not sources:
             return []
-        max_sources = self.config.get("max_sources", 5)
+        max_sources = self._cfg("max_sources", 5)
         if max_sources > 0:
             sources = sources[:max_sources]
         lines = [f"\n{header}:"]
@@ -681,23 +813,24 @@ class GrokSearchPlugin(Star):
         """从文本中提取 URL 作为来源，仅允许 http/https 协议"""
         return [{"url": url, "title": "", "snippet": ""} for url in extract_urls(text)]
 
+    def _supports_forward_output(self, event: AstrMessageEvent) -> bool:
+        return event.get_platform_name() == "aiocqhttp" and bool(event.get_self_id())
+
     def _help_text(self) -> str:
         """返回帮助文本"""
-        use_builtin = self.config.get("use_builtin_provider", False)
+        use_builtin = self._cfg("use_builtin_provider", False)
         mode = "AstrBot 自带" if use_builtin else "自定义"
         provider_id = (
-            (self.config.get("provider", "") or "未配置")
+            (self._cfg("provider", "") or "未配置")
             if use_builtin
-            else (self.config.get("base_url", "") or "未配置")
+            else (self._cfg("base_url", "") or "未配置")
         )
         model = (
             "由供应商决定"
             if use_builtin
-            else (self.config.get("model", DEFAULT_MODEL) or "默认")
+            else (self._cfg("model", DEFAULT_MODEL) or "默认")
         )
-        has_custom_prompt = bool(
-            (self.config.get("custom_system_prompt", "") or "").strip()
-        )
+        has_custom_prompt = bool((self._cfg("custom_system_prompt", "") or "").strip())
         if has_custom_prompt:
             prompt_info = "自定义"
         else:
@@ -735,7 +868,7 @@ class GrokSearchPlugin(Star):
         )
 
     @filter.command("grok")
-    async def grok_cmd(self, event: AstrMessageEvent, query: GreedyStr = ""):
+    async def grok_cmd(self, event: AstrMessageEvent, query: GreedyStr):
         """执行 Grok 搜索
 
         用法: /grok <搜索内容>
@@ -776,7 +909,7 @@ class GrokSearchPlugin(Star):
 
         # 优先使用自定义提示词，未设置则使用内置提示词（英文指令 + JSON 格式 + 中文回复）
         cmd_system_prompt = resolve_system_prompt(
-            self.config.get("custom_system_prompt", ""),
+            self._cfg("custom_system_prompt", ""),
             (
                 "You are a web research assistant. Use live web search/browsing when answering. "
                 "Return ONLY a single JSON object with keys: "
@@ -795,8 +928,13 @@ class GrokSearchPlugin(Star):
         )
         event.should_call_llm(True)
 
+        if self._cfg("send_as_forward", False):
+            forward_sent = await self._send_as_forward(event, result)
+            if forward_sent:
+                return
+
         # 判断是否以图片卡片形式发送
-        use_image = self.config.get("render_as_image", False) and self._card_fonts_ready
+        use_image = self._cfg("render_as_image", False) and self._card_fonts_ready
         image_sent = False
 
         if use_image and result.get("ok"):
@@ -809,6 +947,72 @@ class GrokSearchPlugin(Star):
             except Exception as e:
                 logger.warning(f"[{PLUGIN_NAME}] 发送搜索结果失败: {e}")
 
+    async def _send_as_forward(self, event: AstrMessageEvent, result: dict) -> bool:
+        """使用 OneBot 合并转发发送 /grok 结果。非 OneBot 平台自动降级。"""
+        if not self._supports_forward_output(event):
+            return False
+
+        sender_uin = event.get_self_id()
+        nodes: list[Node] = []
+
+        use_image = (
+            self._cfg("render_as_image", False)
+            and self._card_fonts_ready
+            and result.get("ok")
+        )
+        tmp_path: str | None = None
+        try:
+            if use_image:
+                with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+                    tmp_path = tmp.name
+                render_search_card(
+                    content=result.get("content", ""),
+                    model=self._cfg("model", ""),
+                    elapsed_ms=result.get("elapsed_ms", 0),
+                    total_tokens=(result.get("usage") or {}).get("total_tokens", 0),
+                    output_path=tmp_path,
+                    theme=self._cfg("card_theme", "auto"),
+                )
+                nodes.append(
+                    Node(
+                        uin=sender_uin,
+                        name=FORWARD_SENDER_NAME,
+                        content=[Image.fromFileSystem(tmp_path)],
+                    )
+                )
+            else:
+                nodes.append(
+                    Node(
+                        uin=sender_uin,
+                        name=FORWARD_SENDER_NAME,
+                        content=[Plain(self._format_result(result))],
+                    )
+                )
+
+            if use_image:
+                src_lines = self._render_sources(
+                    result.get("sources", []),
+                    header="来源",
+                    with_snippet=False,
+                )
+                if src_lines:
+                    nodes.append(
+                        Node(
+                            uin=sender_uin,
+                            name=FORWARD_SENDER_NAME,
+                            content=[Plain("\n".join(src_lines).lstrip("\n"))],
+                        )
+                    )
+
+            await event.send(MessageChain([Nodes(nodes)]))
+            return True
+        except Exception as e:
+            logger.warning(f"[{PLUGIN_NAME}] 合并转发发送失败，降级为普通发送: {e}")
+            return False
+        finally:
+            if tmp_path:
+                Path(tmp_path).unlink(missing_ok=True)
+
     async def _send_as_image_card(self, event: AstrMessageEvent, result: dict) -> bool:
         """将搜索结果渲染为图片卡片并发送，附带文本来源链接。
 
@@ -820,8 +1024,8 @@ class GrokSearchPlugin(Star):
         elapsed = result.get("elapsed_ms", 0)
         usage = result.get("usage") or {}
         total_tokens = usage.get("total_tokens", 0)
-        model = self.config.get("model", "")
-        theme = self.config.get("card_theme", "auto")
+        model = self._cfg("model", "")
+        theme = self._cfg("card_theme", "auto")
 
         tmp_path: str | None = None
         image_sent = False
@@ -944,14 +1148,14 @@ class GrokSearchPlugin(Star):
         if not url or not url.startswith("http"):
             return "错误：请提供完整的 HTTP/HTTPS URL"
 
-        base_url = self.config.get("base_url", "")
-        api_key = self.config.get("api_key", "")
-        model = self.config.get("model", DEFAULT_MODEL)
-        timeout = self.config.get("timeout_seconds", 60)
-        proxy = self.config.get("proxy", "") or None
+        base_url = self._cfg("base_url", "")
+        api_key = self._cfg("api_key", "")
+        model = self._cfg("model", DEFAULT_MODEL)
+        timeout = self._cfg("timeout_seconds", 60)
+        proxy = self._cfg("proxy", "") or None
 
-        extra_body_str = self.config.get("extra_body", "")
-        extra_headers_str = self.config.get("extra_headers", "")
+        extra_body_str = self._cfg("extra_body", "")
+        extra_headers_str = self._cfg("extra_headers", "")
         extra_body, _ = parse_json_config(extra_body_str)
         extra_headers, _ = parse_json_config(extra_headers_str)
 
@@ -980,20 +1184,20 @@ class GrokSearchPlugin(Star):
     async def on_astrbot_loaded(self):
         """当 AstrBot 初始化完成后执行的钩子：在启用了自带供应商时完成插件的剩余初始化工作"""
         try:
-            if not self.config.get("use_builtin_provider", False):
+            if not self._cfg("use_builtin_provider", False):
                 return
 
             logger.info(f"[{PLUGIN_NAME}] AstrBot 已初始化，继续完成插件初始化")
 
             # 创建复用的 HTTP 会话（如果配置要求）
-            if self.config.get("reuse_session", False) and (
+            if self._cfg("reuse_session", False) and (
                 self._session is None or self._session.closed
             ):
                 self._session = aiohttp.ClientSession()
 
             # 迁移并根据 enable_skill 安装或卸载 Skill
             self._migrate_skill_to_persistent()
-            if self.config.get("enable_skill", False):
+            if self._cfg("enable_skill", False):
                 self._install_skill()
             else:
                 self._uninstall_skill()

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_grok_web_search
 display_name: Grok联网搜索
 desc: 通过 Grok API 进行实时联网搜索，返回综合答案和来源链接，支持指令，LLM Tool和skills调用。
-version: v1.4.0
+version: v1.4.1
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_grok_web_search
 astrbot_version: ">=4.9.2"

--- a/skill/scripts/grok_search.py
+++ b/skill/scripts/grok_search.py
@@ -39,6 +39,72 @@ from tool import (  # noqa: E402
     normalize_image as _normalize_image,
 )
 
+# ─── 新版分组配置读取（与 main.py CONFIG_PATHS 保持一致）──────────────────
+_CONFIG_PATHS = {
+    "use_builtin_provider": ("provider_settings", "use_builtin_provider"),
+    "provider": ("provider_settings", "provider"),
+    "model": ("provider_settings", "model"),
+    "use_responses_api": ("provider_settings", "use_responses_api"),
+    "base_url": ("connection_settings", "base_url"),
+    "api_key": ("connection_settings", "api_key"),
+    "timeout_seconds": ("connection_settings", "timeout_seconds"),
+    "reuse_session": ("connection_settings", "reuse_session"),
+    "proxy": ("connection_settings", "proxy"),
+    "enable_thinking": ("request_settings", "enable_thinking"),
+    "thinking_budget": ("request_settings", "thinking_budget"),
+    "max_retries": ("request_settings", "max_retries"),
+    "retry_delay": ("request_settings", "retry_delay"),
+    "retryable_status_codes": ("request_settings", "retryable_status_codes"),
+    "custom_system_prompt": ("request_settings", "custom_system_prompt"),
+    "extra_body": ("advanced_settings", "extra_body"),
+    "extra_headers": ("advanced_settings", "extra_headers"),
+    "show_sources": ("output_settings", "show_sources"),
+    "render_as_image": ("output_settings", "render_as_image"),
+    "send_as_forward": ("output_settings", "send_as_forward"),
+    "card_theme": ("output_settings", "card_theme"),
+    "max_sources": ("output_settings", "max_sources"),
+    "enable_fetch": ("tool_settings", "enable_fetch"),
+    "enable_skill": ("tool_settings", "enable_skill"),
+}
+
+_CONFIG_DEFAULTS = {
+    "use_builtin_provider": False,
+    "provider": "",
+    "model": DEFAULT_MODEL,
+    "use_responses_api": False,
+    "base_url": "",
+    "api_key": "",
+    "timeout_seconds": 60,
+    "reuse_session": False,
+    "proxy": "",
+    "enable_thinking": True,
+    "thinking_budget": 32000,
+    "max_retries": 3,
+    "retry_delay": 1.0,
+    "retryable_status_codes": [429, 500, 502, 503, 504],
+    "custom_system_prompt": "",
+    "extra_body": "",
+    "extra_headers": "",
+    "show_sources": False,
+    "render_as_image": False,
+    "send_as_forward": False,
+    "card_theme": "auto",
+    "max_sources": 5,
+    "enable_fetch": False,
+    "enable_skill": False,
+}
+
+
+def _cfg(config: dict[str, Any], key: str):
+    """优先从分组配置读取，fallback 到平铺键和默认值"""
+    path = _CONFIG_PATHS.get(key)
+    if path:
+        section = config.get(path[0])
+        if isinstance(section, dict) and path[1] in section:
+            return section[path[1]]
+    default = _CONFIG_DEFAULTS.get(key)
+    return config.get(key, default)
+
 
 def _compact_json(data: Any) -> str:
     return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=False)
@@ -483,7 +549,9 @@ def main() -> int:
 
     # 优先尝试加载 AstrBot 插件配置
     astrbot_config, astrbot_config_status = _load_astrbot_plugin_config()
-    if astrbot_config and _normalize_api_key(str(astrbot_config.get("api_key") or "")):
+    if astrbot_config and _normalize_api_key(
+        str(_cfg(astrbot_config, "api_key") or "")
+    ):
         config_path = "[AstrBot Plugin Config]"
         config = astrbot_config
 
@@ -511,7 +579,7 @@ def main() -> int:
                 fallback_config = candidate_config
 
             candidate_key = _normalize_api_key(
-                str(candidate_config.get("api_key") or "")
+                str(_cfg(candidate_config, "api_key") or "")
             )
             if candidate_key:
                 config_path = candidate
@@ -528,17 +596,17 @@ def main() -> int:
     base_url = _normalize_base_url_value(
         args.base_url.strip()
         or os.environ.get("GROK_BASE_URL", "").strip()
-        or str(config.get("base_url") or "").strip()
+        or str(_cfg(config, "base_url") or "").strip()
     )
     api_key = _normalize_api_key(
         args.api_key.strip()
         or os.environ.get("GROK_API_KEY", "").strip()
-        or str(config.get("api_key") or "").strip()
+        or str(_cfg(config, "api_key") or "").strip()
     )
     model = (
         args.model.strip()
         or os.environ.get("GROK_MODEL", "").strip()
-        or str(config.get("model") or "").strip()
+        or str(_cfg(config, "model") or "").strip()
         or DEFAULT_MODEL
     )
 
@@ -550,7 +618,7 @@ def main() -> int:
             timeout_seconds = 0.0
     if not timeout_seconds:
         try:
-            timeout_seconds = float(config.get("timeout_seconds") or 0)
+            timeout_seconds = float(_cfg(config, "timeout_seconds") or 0)
         except (ValueError, TypeError):
             timeout_seconds = 0.0
     if not timeout_seconds or timeout_seconds <= 0:
@@ -567,7 +635,7 @@ def main() -> int:
         enable_thinking = False
     else:
         # 从配置文件读取，默认 True
-        cfg_enable_thinking = config.get("enable_thinking")
+        cfg_enable_thinking = _cfg(config, "enable_thinking")
         enable_thinking = (
             cfg_enable_thinking if isinstance(cfg_enable_thinking, bool) else True
         )
@@ -580,7 +648,7 @@ def main() -> int:
             thinking_budget = 0
     if not thinking_budget:
         try:
-            thinking_budget = int(config.get("thinking_budget") or 0)
+            thinking_budget = int(_cfg(config, "thinking_budget") or 0)
         except (ValueError, TypeError):
             thinking_budget = 0
     if not thinking_budget or thinking_budget <= 0:
@@ -588,7 +656,7 @@ def main() -> int:
 
     # 解析 Responses API 开关
     use_responses_api = False
-    cfg_use_responses = config.get("use_responses_api")
+    cfg_use_responses = _cfg(config, "use_responses_api")
     if isinstance(cfg_use_responses, bool):
         use_responses_api = cfg_use_responses
 
@@ -612,7 +680,7 @@ def main() -> int:
 
     try:
         extra_body: dict[str, Any] = {}
-        cfg_extra_body = config.get("extra_body")
+        cfg_extra_body = _cfg(config, "extra_body")
         if isinstance(cfg_extra_body, dict):
             extra_body.update(cfg_extra_body)
         extra_body.update(_load_json_env("GROK_EXTRA_BODY_JSON"))
@@ -621,7 +689,7 @@ def main() -> int:
         )
 
         extra_headers: dict[str, Any] = {}
-        cfg_extra_headers = config.get("extra_headers")
+        cfg_extra_headers = _cfg(config, "extra_headers")
         if isinstance(cfg_extra_headers, dict):
             extra_headers.update(cfg_extra_headers)
         extra_headers.update(_load_json_env("GROK_EXTRA_HEADERS_JSON"))


### PR DESCRIPTION
## 变更
- 修复 /grok 指令搜索内容带空格时只识别首段的问题
- 重写配置文件为分组结构，并保留旧版平铺配置兼容迁移
- 新增 /grok 搜索结果合并转发输出配置

## 关联 Issue
Fixes #11

## 测试

<img width="1188" height="744" alt="Screenshot_2026-05-05-21-50-04-275_com tencent mobileqq" src="https://github.com/user-attachments/assets/abf747be-ad5d-4e42-8d6a-d965fb148c68" />
<img width="1183" height="752" alt="Screenshot_2026-05-05-21-49-51-728_com tencent mobileqq" src="https://github.com/user-attachments/assets/426cdfbd-df12-4c99-9beb-d6309e1cce27" />

## Summary by Sourcery

优化 Grok Web 搜索插件的配置处理、消息解析和输出选项，并新增对 OneBot 平台合并转发消息的支持，同时提升插件版本。

New Features:
- 新增 `send_as_forward` 选项，使 `/grok` 搜索结果可在 OneBot v11/aiocqhttp 上以合并转发的形式发送，并在不支持的平台上自动回退为原有行为。

Bug Fixes:
- 修复 `/grok` 命令解析问题，确保包含空格的查询可以被完整捕获，而不会在第一个片段后被截断。

Enhancements:
- 引入分组配置段（grouped configuration sections），支持从旧的扁平化配置键自动迁移，并新增共享的 `_cfg` 辅助函数，以便在插件和技能脚本中统一读取配置。
- 改进引用/回复消息解析逻辑，优先使用 AstrBot 的 `quoted_message_parser`，在不支持时自动回退到现有的消息链解析方式。
- 将图片 base64 处理重构为统一的辅助工具，支持直接图片、base64/data URI、URL 以及本地路径等多种输入形式。
- 更新 README 和 CHANGELOG，记录新的分组配置、选项和行为变更，并将元数据版本提升至 v1.4.1。

Documentation:
- 更新 README，描述新的分组配置布局、`send_as_forward` 选项，并对配置章节与参数说明进行澄清。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the Grok web search plugin’s configuration handling, message parsing, and output options, while adding support for merged forward messages on OneBot platforms and bumping the plugin version.

New Features:
- Add a `send_as_forward` option to send `/grok` search results as merged forwards on OneBot v11/aiocqhttp with automatic fallback on unsupported platforms.

Bug Fixes:
- Fix `/grok` command parsing so queries containing spaces are fully captured instead of truncating after the first segment.

Enhancements:
- Introduce grouped configuration sections with automatic migration from legacy flat keys and a shared `_cfg` helper for consistent reads in both the plugin and skill script.
- Improve quoted/reply message parsing by preferring AstrBot’s `quoted_message_parser` with automatic fallback to existing chain parsing.
- Refactor image base64 handling into a unified helper that supports direct images, base64/data URIs, URLs, and local paths.
- Update README and CHANGELOG to document the new grouped configuration, options, and behaviors, and bump metadata version to v1.4.1.

Documentation:
- Update README to describe the new grouped configuration layout, the `send_as_forward` option, and clarify configuration sections and parameter descriptions.

</details>